### PR TITLE
test code cleanups

### DIFF
--- a/tests/_testbase.py
+++ b/tests/_testbase.py
@@ -62,8 +62,8 @@ class BaseTestCase(unittest.TestCase):
 
 def _cert_fullname(name):
     fullname = os.path.join(
-        os.path.dirname(os.path.dirname(__file__)),
-        'tests', 'certs', name)
+        os.path.dirname(__file__),
+        'certs', name)
     assert os.path.isfile(fullname)
     return fullname
 

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -8,7 +8,7 @@ else:
 
 import unittest
 
-from uvloop import _testbase as tb
+import _testbase as tb
 
 
 class _TestAioHTTP:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -7,7 +7,7 @@ import uvloop
 import unittest
 
 from unittest import mock
-from uvloop._testbase import UVTestCase, AIOTestCase
+from _testbase import UVTestCase, AIOTestCase
 
 
 class _TestBase:

--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -1,7 +1,7 @@
 import socket
 import unittest
 
-from uvloop import _testbase as tb
+import _testbase as tb
 
 
 _HOST, _PORT = ('example.com', 80)

--- a/tests/test_pipes.py
+++ b/tests/test_pipes.py
@@ -3,7 +3,7 @@ import io
 import os
 
 from asyncio import test_utils
-from uvloop import _testbase as tb
+import _testbase as tb
 
 
 # All tests are copied from asyncio (mostly as-is)

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -6,7 +6,7 @@ import sys
 import tempfile
 
 from asyncio import test_utils
-from uvloop import _testbase as tb
+import _testbase as tb
 
 
 class _TestProcess:

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,12 +1,22 @@
 import asyncio
+import os
 import signal
 import subprocess
 import sys
 import time
 
-from uvloop import _testbase as tb
+import _testbase as tb
 
 DELAY = 0.1
+
+# Explicitly set the current working directory for the subprocesses
+# to ensure they work when run from test entry point location (e.g.
+# via `make test` or from within the tests directory using using
+# `unittest`.
+TESTS_DIR = os.path.dirname(__file__)
+
+_PYTHONPATH = '{}:{}'.format(
+    os.path.dirname(TESTS_DIR), os.environ.get('PYTHONPATH', ''))
 
 
 class _TestSignal:
@@ -20,7 +30,7 @@ import asyncio
 import uvloop
 import time
 
-from uvloop import _testbase as tb
+import _testbase as tb
 
 async def worker():
     print('READY', flush=True)
@@ -37,11 +47,15 @@ def run():
 
 run()
 """
-
+            # explicitly define cwd and env to ensure that
+            # the developmental uvloop is used and that the
+            # tests run from anywhere.
             proc = await asyncio.create_subprocess_exec(
                 sys.executable, b'-c', PROG,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
+                cwd=TESTS_DIR,
+                env={'PYTHONPATH': _PYTHONPATH},
                 loop=self.loop)
 
             await proc.stdout.readline()
@@ -61,7 +75,7 @@ import asyncio
 import uvloop
 import time
 
-from uvloop import _testbase as tb
+import _testbase as tb
 
 async def worker():
     print('READY', flush=True)
@@ -83,11 +97,15 @@ def run():
 
 run()
 """
-
+            # explicitly define cwd and env to ensure that
+            # the developmental uvloop is used and that the
+            # tests run from anywhere.
             proc = await asyncio.create_subprocess_exec(
                 sys.executable, b'-c', PROG,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
+                cwd=TESTS_DIR,
+                env={'PYTHONPATH': _PYTHONPATH},
                 loop=self.loop)
 
             await proc.stdout.readline()

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -1,6 +1,6 @@
 import socket
 
-from uvloop import _testbase as tb
+import _testbase as tb
 
 
 _SIZE = 1024 * 1024

--- a/tests/test_tcp.py
+++ b/tests/test_tcp.py
@@ -3,7 +3,7 @@ import socket
 import uvloop
 import sys
 
-from uvloop import _testbase as tb
+import _testbase as tb
 
 
 class _TestTCP:

--- a/tests/test_udp.py
+++ b/tests/test_udp.py
@@ -4,7 +4,7 @@ import uvloop
 import sys
 
 from asyncio import test_utils
-from uvloop import _testbase as tb
+import _testbase as tb
 
 
 class MyDatagramProto(asyncio.DatagramProtocol):

--- a/tests/test_unix.py
+++ b/tests/test_unix.py
@@ -3,7 +3,7 @@ import os
 import socket
 import tempfile
 
-from uvloop import _testbase as tb
+import _testbase as tb
 
 
 class _TestUnix:


### PR DESCRIPTION
The pull request consolidates all test code into the ``tests`` directory (e.g. ``_testbase.py``) and removes the assumption that tests are only ever run from the top level directory. This change allows the tests to be run with either ``unittest`` or ``pytest`` from either the top level directory or from within the tests directory. 

I typically use the standard library ``unittest`` package to run unit tests and I was using it with uvloop as they all seemed like typical ``unittest`` style tests to me and I saw no mention of using ``pytest``. I tend to use ``unittest`` because it is in the standard library which just reduces the need for one extra dependency. 

Using the common ``unittest`` approach of running individual unit tests from within the tests directory I was getting test failures. The same tests would pass when run using the ``make test`` rule. This discrepancy was because some paths (e.g. to certs) were hard coded to always assume tests are run from the top level directory. 

Via another PR I see that you use ``pytest``, though I don't think there is anything ``pytest`` specific in the tests. This change allows either approach to be used.
