### PR TITLE
Allow dynamic linking to system libuv

### DIFF
--- a/uvloop/includes/uv.pxd
+++ b/uvloop/includes/uv.pxd
@@ -4,7 +4,7 @@ from posix.types cimport gid_t, uid_t
 from . cimport system
 
 
-cdef extern from "../vendor/libuv/include/uv.h" nogil:
+cdef extern from "uv.h" nogil:
     cdef int UV_EACCES
     cdef int UV_EAGAIN
     cdef int UV_EALREADY


### PR DESCRIPTION
Added build_ext option --use-system-libuv to switch between dynamic and static linking.