### PR TITLE
Build manylinux1_x86_64 wheel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,22 @@
 language: python
+sudo: required
 
 os:
     - linux
+
+services:
+    - docker
+
+env:
+    global:
+        - DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64
 
 python:
     - 3.5
 
 install:
-    - "pip install --no-binary=:all: cython"
+    - pip install -U pip
+    - pip install cython
     - "pip install --no-binary=:all: aiohttp"
     - make
 
@@ -18,6 +27,9 @@ before_deploy:
     - rm -rf dist
     - make sdist
     - mv `find dist -name 'uvloop-*.tar.gz' | head -1` uvloop-release.tar.gz
+    - docker pull $DOCKER_IMAGE
+    - docker run --rm -v `pwd`:/io -w /io $DOCKER_IMAGE /opt/python/cp35-cp35m/bin/pip wheel --build-option='-pmanylinux1_x86_64' uvloop-release.tar.gz
+    - mv `find . -name 'uvloop-*-manylinux1_x86_64.whl' | head -1` uvloop-release-cp35-cp35m-manylinux1_x86_64.whl
 
 deploy:
   provider: releases
@@ -26,6 +38,9 @@ deploy:
     secure: Rf7uGIR9IH7wPXHKB7LcdjQN2i0P0l7zsOz1IDzT/aNla/tWkxDawIbWTFE1gqaRwAZNAQvLh3xjPAh4XWAtd3Q06NbOFrL3/2uhwzb7fOyRbtqTN3OWkxBDgaTyNee4zVG/guhuDAp2keMIOA6DAk3ZpbIx6QTWErjo8c5mubQqAFKPmFuRhvYTzqg0TZD+iAaen7neAOXa0LDa23T929J96rHE2JmFG21Wx6tPOV31c5/gQmd6fcmmNL524I6pSz7TeRFKveKX6RJzcQwxJtrCsQNMq1pLqm3bd7cd/2MaaPP1EyHt7FXejnXqB0FPSssCgG5TbRzCpatrzRugsWl86uqVxINK8pE/h5wA0T1EwsdJkTeYitZmpQL3mbndArNWkzS+5AuVNEByuzdSSfBMukCgq6vfQI8vUnfF74UIvuzYlGANvAyCTpI7g3g33pgL+BicG5qGOUGvFBG+j2gmiwqsmwC5OxT2JljhI2s6udOu56hNNa9M+MhEvrEya0mNOoReqrZrQruxM4M9WKEWd3y13VVN2aaPoyNh8BLXYnU+CZ+d+O/j0sXoUwx2NG1yU+xYirsoSR3NVURQu10ZvS+H8H3Uu8C6b+XJYfz3w7LXdyjXKSRIjtbsVNreda6dnRR7NfK9PCG9lgchmVkd9+Cc2DcDwfHOXjdy2qs=
   file:
     - uvloop-release.tar.gz
+    - uvloop-release-cp35-cp35m-manylinux1_x86_64.whl
   on:
     repo: MagicStack/uvloop
     tags: true
+
+# vim: sw=4 ts=4 expandtab


### PR DESCRIPTION
FWIW, this pull request build manylinux1 wheel in Travis using docker.

FYI, cython provides manylinux1 wheel.  When using pip 8.1 or newer, installing cython is ultra fast without --no-binary option.