### PR TITLE
Fixes broken image on PyPi entry

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Performance
 
 uvloop makes asyncio 2-4x faster.
 
-.. image:: performance.png
+.. image:: https://raw.githubusercontent.com/MagicStack/uvloop/master/performance.png
     :target: http://magic.io/blog/uvloop-blazing-fast-python-networking/
 
 The above chart shows the performance of an echo server with different


### PR DESCRIPTION
Preserves Github image rendering and fixes PyPi broken image.

Presuming this same README.rst is used verbatim for both Github and PyPi.