### PR TITLE
Support DragonFlyBSD

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -256,7 +256,7 @@ class uvloop_build_ext(build_ext):
 
         if sys.platform.startswith('linux'):
             self.compiler.add_library('rt')
-        elif sys.platform.startswith('freebsd'):
+        elif sys.platform.startswith(('freebsd', 'dragonfly')):
             self.compiler.add_library('kvm')
         elif sys.platform.startswith('sunos'):
             self.compiler.add_library('kstat')


### PR DESCRIPTION
uvloop project builds w/o kvm but cannot import. KVM required.

This change allows for a python3.6 userland on a DragonFlyBSD HEAD to pass tests.