### PR TITLE
Address argument now has correct help message

### DIFF
--- a/examples/bench/echoclient.py
+++ b/examples/bench/echoclient.py
@@ -22,7 +22,7 @@ if __name__ == '__main__':
     parser.add_argument('--workers', default=3, type=int,
                         help='number of workers')
     parser.add_argument('--addr', default='127.0.0.1:25000', type=str,
-                        help='number of workers')
+                        help='address:port of echoserver')
     args = parser.parse_args()
 
     unix = False


### PR DESCRIPTION
Last argument for address was copied but not fully updated, left out was the 'help' message. This has been updated to be helpful.