### PR TITLE
Fix running of setup.py test with recent setuptools.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,13 +34,13 @@ debug: clean
 		--define UVLOOP_DEBUG,CYTHON_TRACE,CYTHON_TRACE_NOGIL
 
 
-docs: compile
-	cd docs && $(PYTHON) -m sphinx -a -b html . _build/html
+docs:
+	$(PYTHON) setup.py build_ext --inplace build_sphinx
 
 
 test:
-	PYTHONASYNCIODEBUG=1 $(PYTHON) -m unittest discover -s tests
-	$(PYTHON) -m unittest discover -s tests
+	PYTHONASYNCIODEBUG=1 $(PYTHON) setup.py test
+	$(PYTHON) setup.py test
 
 
 release: distclean compile test

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,7 @@
+import unittest
+
+
+def suite():
+    test_loader = unittest.TestLoader()
+    test_suite = test_loader.discover('.', pattern='test_*.py')
+    return test_suite


### PR DESCRIPTION
Referencing "setup" in the "test_suite" setup() argument leads to
setup.py being executed twice, which leads to a broken command
behaviour.