### PR TITLE
Link with pthread

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -267,6 +267,8 @@ class uvloop_build_ext(build_ext):
             self.compiler.add_library('kvm')
         elif sys.platform.startswith('sunos'):
             self.compiler.add_library('kstat')
+            
+        self.compiler.add_library('pthread')
 
         super().build_extensions()
 


### PR DESCRIPTION
When importing uvloop, I got the following error:

    >>> import uvloop
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/projects/RedPitaya/OS/buildroot/buildroot-2017.02/output/target/usr/lib/python3.5/site-packages/uvloop/__init__.py", line 7, in <module>
    ImportError: /usr/lib/python3.5/site-packages/uvloop/loop.cpython-35m-arm-linux-gnueabihf.so: undefined symbol: pthread_atfork

This is fixed by linking the plugin (`loop.cpython-35m-arm-linux-gnueabihf.so`) to pthread as done in this patch.