### PR TITLE
move remove_done_callback to finally block to fix RuntimeError('Event loop stopped before Future completed')

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -295,6 +295,20 @@ class _TestBase:
         with self.assertRaisesRegex(ValueError, 'aaa'):
             self.loop.run_until_complete(foo())
 
+    def test_run_until_complete_loop_orphan_future_close_loop(self):
+        async def foo(sec=0):
+            await asyncio.sleep(sec)
+        self.loop.close()
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            with mock.patch('asyncio.base_events.BaseEventLoop.run_forever', side_effect=Exception):
+                loop.run_until_complete(foo())
+        except:
+            pass
+        loop.run_until_complete(foo(0.1))
+        loop.close()
+
     def test_debug_slow_callbacks(self):
         logger = logging.getLogger('asyncio')
         self.loop.set_debug(True)

--- a/uvloop/loop.pyx
+++ b/uvloop/loop.pyx
@@ -1196,7 +1196,8 @@ cdef class Loop:
                 # local task.
                 future.exception()
             raise
-        future.remove_done_callback(done_cb)
+        finally:
+            future.remove_done_callback(done_cb)
         if not future.done():
             raise RuntimeError('Event loop stopped before Future completed.')
 


### PR DESCRIPTION
@1st1 
This fix is the same as https://github.com/python/cpython/pull/1688

I still don't have clear idea about how the future with callback was left over in the loop.

This fix has proven to be effective in large scale production.