### PR TITLE
Allow for cross-compile of libuv

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -233,8 +233,12 @@ class uvloop_build_ext(build_ext):
              'Makefile.am', 'Makefile.in'],
             cwd=LIBUV_BUILD_DIR, env=env, check=True)
 
+        if 'LIBUV_CONFIGURE_HOST' in env:
+            cmd = ['./configure', '--host=' + env['LIBUV_CONFIGURE_HOST']]
+        else:
+            cmd = ['./configure']
         subprocess.run(
-            ['./configure'],
+            cmd,
             cwd=LIBUV_BUILD_DIR, env=env, check=True)
 
         j_flag = '-j{}'.format(os.cpu_count() or 1)


### PR DESCRIPTION
If LIBUV_CONFIGURE_HOST environment variable is defined, then call
./configure with --host parameter set to LIBUV_CONFIGURE_HOST value.