### PR TITLE
Make Transport.resume_reading() and pause_reading() idempotent. Add is_reading().

### DIFF
--- a/tests/test_tcp.py
+++ b/tests/test_tcp.py
@@ -549,10 +549,15 @@ class Test_UV_TCP(_TestTCP, tb.UVTestCase):
                 t.set_protocol(p)
 
             self.assertFalse(t._paused)
+            self.assertTrue(t.is_reading())
             t.pause_reading()
+            t.pause_reading()  # Check that it's OK to call it 2nd time.
             self.assertTrue(t._paused)
+            self.assertFalse(t.is_reading())
             t.resume_reading()
+            t.resume_reading()  # Check that it's OK to call it 2nd time.
             self.assertFalse(t._paused)
+            self.assertTrue(t.is_reading())
 
             sock = t.get_extra_info('socket')
             self.assertIs(sock, t.get_extra_info('socket'))
@@ -579,6 +584,12 @@ class Test_UV_TCP(_TestTCP, tb.UVTestCase):
             self.assertFalse(t._closing)
             t.abort()
             self.assertTrue(t._closing)
+
+            self.assertFalse(t.is_reading())
+            # Check that pause_reading and resume_reading don't raise
+            # errors if called after the transport is closed.
+            t.pause_reading()
+            t.resume_reading()
 
             await fut
 

--- a/uvloop/handles/stream.pyx
+++ b/uvloop/handles/stream.pyx
@@ -664,21 +664,16 @@ cdef class UVStream(UVBaseTransport):
     def can_write_eof(self):
         return True
 
-    def pause_reading(self):
-        self._ensure_alive()
+    def is_reading(self):
+        return self._is_reading()
 
-        if self._closing:
-            raise RuntimeError('Cannot pause_reading() when closing')
-        if not self._is_reading():
-            raise RuntimeError('Already paused')
+    def pause_reading(self):
+        if self._closing or not self._is_reading():
+            return
         self._stop_reading()
 
     def resume_reading(self):
-        self._ensure_alive()
-
-        if self._is_reading():
-            raise RuntimeError('Not paused')
-        if self._closing:
+        if self._is_reading() or self._closing:
             return
         self._start_reading()
 


### PR DESCRIPTION
Fixes issue #93.
Implements https://github.com/python/cpython/pull/528 asyncio change.