### PR TITLE
Convert Future-returning loop methods to coroutines.

### DIFF
--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -1,3 +1,4 @@
+import asyncio
 import socket
 import unittest
 
@@ -165,7 +166,9 @@ class Test_UV_DNS(BaseTestDNS, tb.UVTestCase):
             raise unittest.SkipTest
 
         async def run():
-            fut = self.loop.getaddrinfo('example.com', 80)
+            fut = self.loop.create_task(
+                self.loop.getaddrinfo('example.com', 80))
+            await asyncio.sleep(0, loop=self.loop)
             fut.cancel()
             self.loop.stop()
 

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -544,7 +544,7 @@ class TestUVSockets(_TestSockets, tb.UVTestCase):
             fut.cancel()
 
         async def recv(sock):
-            fut = self.loop.sock_recv(sock, 10)
+            fut = self.loop.create_task(self.loop.sock_recv(sock, 10))
             await asyncio.sleep(0.1, loop=self.loop)
             self.loop.remove_reader(sock)
             sock.close()

--- a/tests/test_unix.py
+++ b/tests/test_unix.py
@@ -461,7 +461,7 @@ class _TestSSL(tb.SSLTestCase):
     def test_create_unix_server_ssl_1(self):
         CNT = 0           # number of clients that were successful
         TOTAL_CNT = 25    # total number of clients that test will create
-        TIMEOUT = 5.0     # timeout for this test
+        TIMEOUT = 10.0    # timeout for this test
 
         A_DATA = b'A' * 1024 * 1024
         B_DATA = b'B' * 1024 * 1024


### PR DESCRIPTION
The following event loop methods are now coroutines:

* getaddrinfo()
* sock_recv()
* sock_recv_into()
* sock_accept()
* subprocess_shell()
* subprocess_exec()