### PR TITLE
Support for PY37 without contextvars.

### DIFF
--- a/tests/test_pipes.py
+++ b/tests/test_pipes.py
@@ -1,8 +1,8 @@
 import asyncio
 import io
 import os
+import socket
 
-from asyncio import test_utils
 from uvloop import _testbase as tb
 
 
@@ -81,11 +81,11 @@ class _BasePipeTest:
         self.loop.run_until_complete(connect())
 
         os.write(wpipe, b'1')
-        test_utils.run_until(self.loop, lambda: proto.nbytes >= 1)
+        tb.run_until(self.loop, lambda: proto.nbytes >= 1)
         self.assertEqual(1, proto.nbytes)
 
         os.write(wpipe, b'2345')
-        test_utils.run_until(self.loop, lambda: proto.nbytes >= 5)
+        tb.run_until(self.loop, lambda: proto.nbytes >= 5)
         self.assertEqual(['INITIAL', 'CONNECTED'], proto.state)
         self.assertEqual(5, proto.nbytes)
 
@@ -114,11 +114,11 @@ class _BasePipeTest:
         self.loop.run_until_complete(connect())
 
         os.write(slave, b'1')
-        test_utils.run_until(self.loop, lambda: proto.nbytes)
+        tb.run_until(self.loop, lambda: proto.nbytes)
         self.assertEqual(1, proto.nbytes)
 
         os.write(slave, b'2345')
-        test_utils.run_until(self.loop, lambda: proto.nbytes >= 5)
+        tb.run_until(self.loop, lambda: proto.nbytes >= 5)
         self.assertEqual(['INITIAL', 'CONNECTED'], proto.state)
         self.assertEqual(5, proto.nbytes)
 
@@ -158,11 +158,11 @@ class _BasePipeTest:
             data += chunk
             return len(data)
 
-        test_utils.run_until(self.loop, lambda: reader(data) >= 1)
+        tb.run_until(self.loop, lambda: reader(data) >= 1)
         self.assertEqual(b'1', data)
 
         transport.write(b'2345')
-        test_utils.run_until(self.loop, lambda: reader(data) >= 5)
+        tb.run_until(self.loop, lambda: reader(data) >= 5)
         self.assertEqual(b'12345', data)
         self.assertEqual('CONNECTED', proto.state)
 
@@ -177,7 +177,7 @@ class _BasePipeTest:
         self.assertEqual('CLOSED', proto.state)
 
     def test_write_pipe_disconnect_on_close(self):
-        rsock, wsock = test_utils.socketpair()
+        rsock, wsock = socket.socketpair()
         rsock.setblocking(False)
 
         pipeobj = io.open(wsock.detach(), 'wb', 1024)
@@ -223,12 +223,12 @@ class _BasePipeTest:
             data += chunk
             return len(data)
 
-        test_utils.run_until(self.loop, lambda: reader(data) >= 1,
+        tb.run_until(self.loop, lambda: reader(data) >= 1,
                              timeout=10)
         self.assertEqual(b'1', data)
 
         transport.write(b'2345')
-        test_utils.run_until(self.loop, lambda: reader(data) >= 5,
+        tb.run_until(self.loop, lambda: reader(data) >= 5,
                              timeout=10)
         self.assertEqual(b'12345', data)
         self.assertEqual('CONNECTED', proto.state)

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -9,7 +9,6 @@ import tempfile
 import time
 import unittest
 
-from asyncio import test_utils
 from uvloop import _testbase as tb
 
 
@@ -504,7 +503,7 @@ class _AsyncioTests:
 
         # ignore the log:
         # "Exception during subprocess creation, kill the subprocess"
-        with test_utils.disable_logger():
+        with tb.disable_logger():
             self.loop.run_until_complete(cancel_make_transport())
 
     def test_cancel_post_init(self):
@@ -522,9 +521,9 @@ class _AsyncioTests:
 
         # ignore the log:
         # "Exception during subprocess creation, kill the subprocess"
-        with test_utils.disable_logger():
+        with tb.disable_logger():
             self.loop.run_until_complete(cancel_make_transport())
-            test_utils.run_briefly(self.loop)
+            tb.run_briefly(self.loop)
 
 
 class Test_UV_Process(_TestProcess, tb.UVTestCase):

--- a/tests/test_udp.py
+++ b/tests/test_udp.py
@@ -3,7 +3,6 @@ import socket
 import unittest
 import sys
 
-from asyncio import test_utils
 from uvloop import _testbase as tb
 
 
@@ -77,9 +76,9 @@ class _TestUDP:
         self.assertIs(client.transport, transport)
 
         transport.sendto(b'xxx')
-        test_utils.run_until(self.loop, lambda: server.nbytes)
+        tb.run_until(self.loop, lambda: server.nbytes)
         self.assertEqual(3, server.nbytes)
-        test_utils.run_until(self.loop, lambda: client.nbytes)
+        tb.run_until(self.loop, lambda: client.nbytes)
 
         # received
         self.assertEqual(8, client.nbytes)

--- a/tests/test_unix.py
+++ b/tests/test_unix.py
@@ -5,6 +5,7 @@ import socket
 import tempfile
 import time
 import unittest
+import sys
 
 from uvloop import _testbase as tb
 
@@ -362,6 +363,7 @@ class _TestUnix:
         self.assertIn(excs[0].__class__,
                       (BrokenPipeError, ConnectionResetError))
 
+    @unittest.skipUnless(sys.version_info < (3, 7), 'Python version must be < 3.7')
     def test_transport_unclosed_warning(self):
         async def test(sock):
             return await self.loop.create_unix_connection(

--- a/uvloop/includes/stdlib.pxi
+++ b/uvloop/includes/stdlib.pxi
@@ -38,10 +38,10 @@ cdef aio_iscoroutinefunction = asyncio.iscoroutinefunction
 cdef aio_BaseProtocol = asyncio.BaseProtocol
 cdef aio_Protocol = asyncio.Protocol
 cdef aio_SSLProtocol = asyncio.sslproto.SSLProtocol
-cdef aio_debug_wrapper = asyncio.coroutines.debug_wrapper
 cdef aio_isfuture = getattr(asyncio, 'isfuture', None)
 cdef aio_get_running_loop = getattr(asyncio, '_get_running_loop', None)
 cdef aio_set_running_loop = getattr(asyncio, '_set_running_loop', None)
+cdef aio_debug_wrapper = getattr(asyncio.coroutines, 'debug_wrapper', None)
 
 cdef col_deque = collections.deque
 cdef col_Iterable = collections.Iterable

--- a/uvloop/loop.pxd
+++ b/uvloop/loop.pxd
@@ -29,11 +29,14 @@ ctypedef object (*method2_t)(object, object, object)
 ctypedef object (*method3_t)(object, object, object, object)
 
 
+
 cdef class Loop:
     cdef:
         uv.uv_loop_t *uvloop
 
-        bint _coroutine_wrapper_set
+
+        bint _coroutine_debug_set
+        int _coroutine_origin_tracking_saved_depth
 
         public slow_callback_duration
 
@@ -194,7 +197,7 @@ cdef class Loop:
     cdef _read_from_self(self)
     cdef _process_self_data(self, data)
 
-    cdef _set_coroutine_wrapper(self, bint enabled)
+    cdef _set_coroutine_debug(self, bint enabled)
 
     cdef _print_debug_info(self)
 


### PR DESCRIPTION
This MR aligns the uvloop code to become compatible, not production
ready, with PY37 adding the following changes:

* Support for the new API used behind the set_debug function.

* Adds the context=None KW to those functions that will receive it
  when uvloop runs with PY37.

* Former asyncio.test_utils moved as an uvloop test resource.

--
Yury: the original PR for this change is #138.  I stripped out
all the CI bits and squashed all commits by hand.  The CI
will be addressed later.

The author of this PR is @pfreixes, I'm just committing his changes by hand.