### PR TITLE
POC UVloop tracing, support for DNS traces and create Task traces

### DIFF
--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,9 +1,13 @@
 # LICENSE: PSF.
 
 import asyncio
+import sys
+import unittest
 
 from uvloop import _testbase as tb
-from uvloop import tracing, TracingCollector
+
+
+PY37 = sys.version_info >= (3, 7, 0)
 
 
 class Dummy:
@@ -350,7 +354,9 @@ class Test_UV_UV_Tasks(_TestTasks, tb.UVTestCase):
     def create_task(self, coro):
         return self.loop.create_task(coro)
 
+    @unittest.skipUnless(PY37, 'requires Python 3.7')
     def test_create_task_tracing(self):
+        from uvloop import tracing, TracingCollector
 
         @asyncio.coroutine
         def coro():

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -3,6 +3,7 @@
 import asyncio
 
 from uvloop import _testbase as tb
+from uvloop import tracing, TracingCollector
 
 
 class Dummy:
@@ -348,6 +349,29 @@ class Test_UV_UV_Tasks(_TestTasks, tb.UVTestCase):
 
     def create_task(self, coro):
         return self.loop.create_task(coro)
+
+    def test_create_task_tracing(self):
+
+        @asyncio.coroutine
+        def coro():
+            pass
+
+        class CreateTaskCollector(TracingCollector):
+            task_created_called = False
+
+            def task_created(self, *args):
+                self.task_created_called = True
+
+        collector = CreateTaskCollector()
+        with tracing(collector):
+            self.create_task(coro())
+        assert collector.task_created_called
+
+        collector.task_created_called = False
+        self.create_task(coro())
+        assert not collector.task_created_called
+
+        tb.run_briefly(self.loop)
 
 
 class Test_UV_UV_Tasks_AIO_Future(_TestTasks, tb.UVTestCase):

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1,0 +1,86 @@
+# LICENSE: PSF.
+
+import asyncio
+import sys
+import unittest
+
+from uvloop import _testbase as tb
+
+
+PY37 = sys.version_info >= (3, 7, 0)
+
+
+if PY37:
+    from uvloop import tracing, TracingCollector
+
+
+class TestTracingCollector(unittest.TestCase):
+    @unittest.skipUnless(PY37, 'requires Python 3.7')
+    def test_tracing_methods(self):
+        collector = TracingCollector()
+        assert hasattr(collector, 'dns_request_begin')
+        assert hasattr(collector, 'dns_request_end')
+        assert hasattr(collector, 'task_created')
+
+
+class TestTracing(tb.UVTestCase):
+
+    @unittest.skipUnless(PY37, 'requires Python 3.7')
+    def test_invalid_collector(self):
+        with self.assertRaises(ValueError):
+            with tracing(None):
+                pass
+
+    @unittest.skipIf(PY37, 'requires Python <3.7')
+    def test_none_compatible_python_version(self):
+        from uvloop.loop import tracing
+        with self.assertRaises(NotImplementedError):
+            with tracing(None):
+                pass
+
+    @unittest.skipUnless(PY37, 'requires Python 3.7')
+    def test_multiple_collectors(self):
+
+        @asyncio.coroutine
+        def coro():
+            pass
+
+        class Collector(TracingCollector):
+            task_created_called = 0
+
+            def task_created(self, *args):
+                self.task_created_called += 1
+
+        collector_a = Collector()
+        with tracing(collector_a):
+            collector_b = Collector()
+            with tracing(collector_b):
+                self.loop.create_task(coro())
+                assert collector_a.task_created_called == 1
+                assert collector_b.task_created_called == 1
+
+            self.loop.create_task(coro())
+            assert collector_a.task_created_called == 2
+            assert collector_b.task_created_called == 1
+
+        self.loop.create_task(coro())
+        assert collector_a.task_created_called == 2
+        assert collector_b.task_created_called == 1
+
+        tb.run_briefly(self.loop)
+
+    @unittest.skipUnless(PY37, 'requires Python 3.7')
+    def test_collectors_do_not_break_the_execution(self):
+
+        @asyncio.coroutine
+        def coro():
+            pass
+
+        class Collector(TracingCollector):
+            def task_created(self, *args):
+                raise Exception()
+
+        with tracing(Collector()):
+            self.loop.create_task(coro())
+
+        tb.run_briefly(self.loop)

--- a/uvloop/__init__.py
+++ b/uvloop/__init__.py
@@ -1,13 +1,19 @@
 import asyncio
 
 from asyncio.events import BaseDefaultEventLoopPolicy as __BasePolicy
+from sys import version_info
 
 from . import includes as __includes  # NOQA
 from . import _patch  # NOQA
 from .loop import Loop as __BaseLoop  # NOQA
 
+PY37 = version_info >= (3, 7, 0)
 
-__all__ = ('new_event_loop', 'EventLoopPolicy')
+if PY37:
+    from .loop import tracing, TracingCollector
+    __all__ = ('new_event_loop', 'EventLoopPolicy', 'tracing', 'TracingCollector')
+else:
+    __all__ = ('new_event_loop', 'EventLoopPolicy')
 
 
 class Loop(__BaseLoop, asyncio.AbstractEventLoop):

--- a/uvloop/dns.pyx
+++ b/uvloop/dns.pyx
@@ -249,6 +249,7 @@ cdef class AddrInfoRequest(UVRequest):
     cdef:
         system.addrinfo hints
         object callback
+        object context
         uv.uv_getaddrinfo_t _req_data
 
     def __cinit__(self, Loop loop,
@@ -277,6 +278,11 @@ cdef class AddrInfoRequest(UVRequest):
             ex = socket_gaierror(socket_EAI_NONAME, msg)
             callback(ex)
             return
+
+        if PY37:
+            self.context = <object>PyContext_CopyCurrent()
+        else:
+            self.context = None
 
         memset(&self.hints, 0, sizeof(system.addrinfo))
         self.hints.ai_flags = flags
@@ -336,6 +342,9 @@ cdef void __on_addrinfo_resolved(uv.uv_getaddrinfo_t *resolver,
         object callback = request.callback
         AddrInfo ai
 
+    if PY37:
+        PyContext_Enter(<PyContext*>request.context)
+
     try:
         if status < 0:
             callback(convert_error(status))
@@ -347,7 +356,8 @@ cdef void __on_addrinfo_resolved(uv.uv_getaddrinfo_t *resolver,
         loop._handle_exception(ex)
     finally:
         request.on_done()
-
+        if PY37:
+            PyContext_Exit(<PyContext*>request.context)
 
 cdef void __on_nameinfo_resolved(uv.uv_getnameinfo_t* req,
                                  int status,

--- a/uvloop/includes/compat.h
+++ b/uvloop/includes/compat.h
@@ -35,6 +35,10 @@ typedef struct {
     PyObject_HEAD
 } PyContext;
 
+typedef struct {
+    PyObject_HEAD
+} PyContextVar;
+
 PyContext * PyContext_CopyCurrent(void) {
     return NULL;
 };
@@ -44,6 +48,10 @@ int PyContext_Enter(PyContext *ctx) {
 }
 
 int PyContext_Exit(PyContext *ctx) {
+    return -1;
+}
+
+int PyContextVar_Get(PyContextVar *var, PyObject *default_value, PyObject **value) {
     return -1;
 }
 #endif

--- a/uvloop/includes/python.pxd
+++ b/uvloop/includes/python.pxd
@@ -17,6 +17,10 @@ cdef extern from "Python.h":
 
 cdef extern from "includes/compat.h":
     ctypedef struct PyContext
+    ctypedef struct PyContextVar
+    ctypedef struct PyObject
     PyContext* PyContext_CopyCurrent() except NULL
     int PyContext_Enter(PyContext *) except -1
     int PyContext_Exit(PyContext *) except -1
+    int PyContextVar_Get(
+        PyContextVar *var, object default_value, PyObject **value) except -1

--- a/uvloop/loop.pxd
+++ b/uvloop/loop.pxd
@@ -229,3 +229,5 @@ include "request.pxd"
 include "handles/udp.pxd"
 
 include "server.pxd"
+
+include "tracing.pxd"

--- a/uvloop/tracing.pxd
+++ b/uvloop/tracing.pxd
@@ -1,0 +1,13 @@
+ctypedef enum traces:
+    TRACE_TASK_CREATED,
+    TRACE_DNS_REQUEST_BEGIN,
+    TRACE_DNS_REQUEST_END
+
+cdef class TracingCollector:
+    cpdef dns_request_begin(self, object host, object port, object family,
+                            object type, object proto, object flags)
+    cpdef dns_request_end(self, object result)
+    cpdef task_created(self, object task)
+
+cdef __send_trace(traces trace, object arg1=*, object arg2=*, object arg3=*,
+                  object arg4=*, object arg5=*, object arg6=*)

--- a/uvloop/tracing.pyx
+++ b/uvloop/tracing.pyx
@@ -1,0 +1,68 @@
+from collections import deque
+from contextlib import contextmanager
+
+
+cdef class TracingCollector:
+    cpdef dns_request_begin(self, host, port, family, type, proto, flags):
+        """Called when a DNS request starts"""
+
+    cpdef dns_request_end(self, result):
+        """Called when a DNS request finishes, result can contain either
+        the response when finished successfully or an exception if it finished
+        with an error"""
+
+    cpdef task_created(self, task):
+        """Called when a new task is created"""
+
+
+if PY37:
+    import contextvars
+
+    __collectors = contextvars.ContextVar('__collectors', default=None)
+
+    @contextmanager
+    def tracing(collector):
+        if not isinstance(collector, TracingCollector):
+            raise ValueError(
+                "collector must be a TracingCollector class instance")
+
+        collectors = __collectors.get(None)
+        if collectors is None:
+            collectors = list()
+            __collectors.set(collectors)
+        collectors.append(collector)
+        yield
+        collectors.pop()
+        if not collectors:
+            __collectors.set(None)
+else:
+    @contextmanager
+    def tracing(*args, **kwargs):
+        raise NotImplementedError(
+            "tracing only supported by Python 3.7 or newer versions")
+
+
+cdef inline __send_trace(traces trace, arg1=None, arg2=None, arg3=None,
+                         arg4=None, arg5=None, arg6=None):
+    cdef:
+        PyObject* collectors = NULL
+
+    if not PY37:
+        return
+
+    PyContextVar_Get(<PyContextVar*> __collectors, None, &collectors)
+    if <object>collectors is not None:
+        for collector in <list>collectors:
+            try:
+                if trace == TRACE_TASK_CREATED:
+                    (<TracingCollector>collector).task_created(arg1)
+                elif trace == TRACE_DNS_REQUEST_BEGIN:
+                    (<TracingCollector>collector).dns_request_begin(arg1, arg2,
+                                                                    arg3, arg4,
+                                                                    arg5, arg6)
+                elif trace == TRACE_DNS_REQUEST_END:
+                    (<TracingCollector>collector).dns_request_end(arg1)
+            except Exception as exc:
+                aio_logger.error(
+                    'trace finished with an exception %r',
+                    exc)


### PR DESCRIPTION
This is the first PR that implements POC that gives to uvloop the
capacity of emit traces that later can be collected by the upper layers.
What does this commit implement?

- DNS traces triggered by the calls to the `getaddrinfo` loop
  method.
- Create task traces emitted by the `create_task` loop method.
- The enabler and disabler context manager called `tracing`.
- The collector interface used to gather the trace events called
  `TracingCollector.
- The capacity of install many nested collectors

This POC assumes that the caller is the last responsible for implementing
a context that put together with traces that belong to different tasks. Take
a look at this snippet [1]

Regarding the overhead of this POC, initial figures say that the performance
footprint, while there are no collectors installed, is almost negligible [2].

(master) Cost per task 5.2499999999417925e-06
(traces) No collectors: Cost task 5.240000000048895e-06
(traces) default method: Cost per task 5.3500000000349245e-06
(traces) Collector method: Cost per task 5.409999999974389e-06

There is still some pending stuff related to this PR that is not solved:

- More robust tests for the DNS instrumentalization, right now params are not asserted.
- Instrumentalize `_getnameinfo`.
- More testing regarding `AddrInfoRequest`.

But before I would like to gather your thoughts with this MR, I will make the proper comments in some parts of the code that can delicate.

[1] https://gist.github.com/pfreixes/5e9cccc4f5881de003243879edd5c470
[2] https://gist.github.com/pfreixes/18f0c678a9a018be0f376d4bef6d722a