### PR TITLE
POC Tracing support

### DIFF
--- a/uvloop/__init__.py
+++ b/uvloop/__init__.py
@@ -1,15 +1,21 @@
 import asyncio
 
 from asyncio.events import BaseDefaultEventLoopPolicy as __BasePolicy
+from sys import version_info
 
 from . import includes as __includes  # NOQA
 from . import _patch  # NOQA
 from .loop import Loop as __BaseLoop  # NOQA
 
+PY37 = version_info >= (3, 7, 0)
+
+if PY37:
+    from .loop import start_tracing, stop_tracing
+    __all__ = ('new_event_loop', 'EventLoopPolicy', 'start_tracing', 'stop_tracing')
+else:
+    __all__ = ('new_event_loop', 'EventLoopPolicy')
 
 __version__ = '0.11.0.dev0'
-__all__ = ('new_event_loop', 'EventLoopPolicy')
-
 
 class Loop(__BaseLoop, asyncio.AbstractEventLoop):
     pass

--- a/uvloop/includes/compat.h
+++ b/uvloop/includes/compat.h
@@ -35,6 +35,10 @@ typedef struct {
     PyObject_HEAD
 } PyContext;
 
+typedef struct {
+    PyObject_HEAD
+} PyContextVar;
+
 PyContext * PyContext_CopyCurrent(void) {
     abort();
     return NULL;
@@ -47,6 +51,10 @@ int PyContext_Enter(PyContext *ctx) {
 
 int PyContext_Exit(PyContext *ctx) {
     abort();
+    return -1;
+}
+
+int PyContextVar_Get(PyContextVar *var, PyObject *default_value, PyObject **value) {
     return -1;
 }
 #endif

--- a/uvloop/includes/python.pxd
+++ b/uvloop/includes/python.pxd
@@ -17,6 +17,10 @@ cdef extern from "Python.h":
 
 cdef extern from "includes/compat.h":
     ctypedef struct PyContext
+    ctypedef struct PyContextVar
+    ctypedef struct PyObject
     PyContext* PyContext_CopyCurrent() except NULL
     int PyContext_Enter(PyContext *) except -1
     int PyContext_Exit(PyContext *) except -1
+    int PyContextVar_Get(
+        PyContextVar *var, object default_value, PyObject **value) except -1

--- a/uvloop/loop.pxd
+++ b/uvloop/loop.pxd
@@ -230,3 +230,5 @@ include "request.pxd"
 include "handles/udp.pxd"
 
 include "server.pxd"
+
+include "tracing.pxd"

--- a/uvloop/tracing.pxd
+++ b/uvloop/tracing.pxd
@@ -1,0 +1,10 @@
+cdef class TracedContext:
+    cdef:
+        object _tracer
+        object _span
+        object _root_span
+
+    cdef object start_span(self, name, tags=?)
+    cdef object current_span(self)
+
+cdef TracedContext __traced_context()

--- a/uvloop/tracing.py
+++ b/uvloop/tracing.py
@@ -1,0 +1,24 @@
+import abc
+
+class Span(abc.ABC):
+
+    @abc.abstractmethod
+    def set_tag(self, key, value):
+        """Tag the span with an arbitrary key and value."""
+
+    @abc.abstractmethod
+    def finish(self, finish_time=None):
+        """Indicate that the work represented by this span
+        has been completed or terminated."""
+
+    @abc.abstractproperty
+    def is_finished(self):
+        """Return True if the current span is already finished."""
+
+
+class Tracer(abc.ABC):
+
+    @abc.abstractmethod
+    def start_span(self, name, parent_span):
+        """Start a new Span with a specific name. The parent of the span
+        will be also passed as a paramter."""

--- a/uvloop/tracing.pyx
+++ b/uvloop/tracing.pyx
@@ -1,0 +1,71 @@
+from contextlib import contextmanager
+
+if PY37:
+    import contextvars
+    __traced_ctx = contextvars.ContextVar('__traced_ctx', default=None)
+else:
+    __traced_ctx = None
+
+
+cdef class TracedContext:
+    def __cinit__(self, tracer, root_span):
+        self._tracer = tracer
+        self._root_span = root_span
+        self._span = None
+
+    cdef object start_span(self, name, tags=None):
+        parent_span = self._span if self._span else self._root_span
+        span = self._tracer.start_span(name, parent_span)
+
+        if tags:
+            for key, value in tags.items():
+                span.set_tag(key, value)
+
+        self._span = span
+        return self._span
+
+    cdef object current_span(self):
+        return self._span
+
+
+cdef inline TracedContext __traced_context():
+    cdef:
+        PyObject* traced_context = NULL
+
+    if not PY37:
+        return
+
+    PyContextVar_Get(<PyContextVar*> __traced_ctx, None, &traced_context)
+
+    if <object>traced_context is None:
+        return
+    return <TracedContext>traced_context
+
+
+def start_tracing(tracer, root_span):
+    if not PY37:
+        raise RuntimeError(
+            "tracing only supported by Python 3.7 or newer versions")
+
+    traced_context = __traced_ctx.get(None)
+    if traced_context is not None:
+        raise RuntimeError("Tracing already started")
+
+    traced_context = TracedContext(tracer, root_span)
+    __traced_ctx.set(traced_context)
+
+
+def stop_tracing():
+    if not PY37:
+        raise RuntimeError(
+            "tracing only supported by Python 3.7 or newer versions")
+
+    traced_context = __traced_context()
+    if traced_context is None:
+        return
+
+    span = traced_context.current_span()
+    if span and not span.is_finished:
+        span.finish()
+
+    __traced_ctx.set(None)


### PR DESCRIPTION
Implements a new tracing support for uvloop adding the pair methods
`start_tracing` and `stop_tracing` that allows the user to start or
stop the tracing. The user must provide a valid `uvloop.tracing.Tracer`
implementation that would be used internally by uvloop to create spans,
each span must also meet the `uvloop.tracing.Span` class contract.

This POC only implements the creation of spans during underlying calls
to the `getaddrinfo` function.

This POC relates to the conversation in #163.

What is missing/What is pending to discuss:

- `uvloop.tracing.Tracer.current_span` needs to be adapted to avoid race conditions, when a span is created the "global" attribute is overwritten. Most likely `current_span` will end up as another context variable.

- Agreement of an almost final draft of the `start_tracing` entry point, right now the implementation hides the `TracedContext`, so making it usable only internally by uvloop. Im wondering if we must make it public providing to the user a way of creating spans in his code, so becoming the way of trace ~asyncio~ uvloop code.

- Current implemetation implicitly wires the Tracer context using the parent span, so for example when internally a new span is created suing the `TracedContext.start_span` under the hood the parent span is passed to the `Tracer.create_span`, so allowing to the tracer to fetch some context information from this, also allowing make the new span child of the the parent one. Should we reconsidere this witih a more explicit interface ?

- Support for other spans within uvloop. But before doing this, we would need a kind of agreement of behind what circumstances the spans are created. A good example is the `create_connection` loop function, would be feel confortable with somehting like this:

```python:
async def create_connection(...)
    with __traced_context() as span:
        .....
```

That it would mean that when there is no tracing enabled it will create a noop span, the benefits of this global wrapping is making the code cleaner and easier to mantain but the drawbacks are quite clear.

Also worth mentioning that going to a pattern that uses a global context would mean that we will be creating a span when indeed in some failure scenarios we connected to nothing and without yielding the loop.