### PR TITLE
Fix EOF for buffered app protocol

### DIFF
--- a/uvloop/handles/stream.pyx
+++ b/uvloop/handles/stream.pyx
@@ -953,7 +953,12 @@ cdef void __uv_stream_buffered_on_read(uv.uv_stream_t* stream,
         return
 
     try:
-        if not sc._read_pybuf_acquired:
+        if nread > 0 and not sc._read_pybuf_acquired:
+            # From libuv docs:
+            #     nread is > 0 if there is data available or < 0 on error. When
+            #     we’ve reached EOF, nread will be set to UV_EOF. When
+            #     nread < 0, the buf parameter might not point to a valid
+            #     buffer; in that case buf.len and buf.base are both set to 0.
             raise RuntimeError(
                 f'no python buffer is allocated in on_read; nread={nread}')
 


### PR DESCRIPTION
`UV_EOF` is given to `read_cb()` on EOF, which causes an error like this:

```
Unexpected calls to loop.call_exception_handler():
[{'exception': RuntimeError('no python buffer is allocated in on_read; nread=-4095',),
  'message': 'Fatal error on transport UnixTransport',
  'protocol': <uvloop.loop.SSLProtocol object at 0x7f1749684630>,
  'transport': <UnixTransport closed=True reading=False 0x7f17496eb6c8>},
 {'exception': RuntimeError('no python buffer is allocated in on_read; nread=-4095',),
  'message': 'Fatal error on transport UnixTransport',
  'protocol': <uvloop.loop.SSLProtocol object at 0x7f1749650470>,
  'transport': <UnixTransport closed=True reading=False 0x7f1749643a08>}]
FAIL

======================================================================
FAIL: test_create_unix_connection_ssl_1 (tests.test_unix.Test_UV_UnixSSL)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/decentfox/uvloop/uvloop/_testbase.py", line 102, in tearDown
    self.fail('unexpected calls to loop.call_exception_handler()')
AssertionError: unexpected calls to loop.call_exception_handler()
```

This failing test was found in #176, but it was unstable. ~Let me try to make a stable test for this fix.~

Related upstream issue: https://github.com/joyent/libuv/issues/803