### PR TITLE
Add python 3.7 on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,13 @@ matrix:
           env: BUILD=tests,wheels PYTHON_VERSION=3.6.5
           branches: {only: [releases]}
 
+        - os: osx
+          osx_image: xcode7.3
+          # Travis macOS env does not support Python yet,
+          # so we have to set things up manually in install.sh.
+          env: BUILD=tests,wheels PYTHON_VERSION=3.7.0
+          branches: {only: [releases]}
+
         - os: linux
           dist: trusty
           sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,17 @@ matrix:
           services: [docker]
           env: BUILD=tests,wheels,release
 
+        - os: linux
+          dist: xenial
+          branches: {only: [releases]}
+          sudo: required
+          language: python
+          python: "3.7"
+          services: [docker]
+          env: BUILD=tests,wheels,release
+
+cache:
+
 cache:
     pip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: generic
 env:
     global:
         - PYMODULE=uvloop
-        - RELEASE_PYTHON_VERSIONS="3.5 3.6"
+        - RELEASE_PYTHON_VERSIONS="3.5 3.6 3.7"
 
         - S3_UPLOAD_USERNAME=oss-ci-bot
         - S3_UPLOAD_BUCKET=magicstack-oss-releases
@@ -80,8 +80,6 @@ matrix:
           python: "3.7"
           services: [docker]
           env: BUILD=tests,wheels,release
-
-cache:
 
 cache:
     pip


### PR DESCRIPTION
Hi,

This `PR` is an attempt to add CI on **python** `3.7`

- [x] Linux 
- [x] OSX
- [x] Windows

**3.7** is not available by default on travis / linux @see https://github.com/travis-ci/travis-ci/issues/9831

Windows is already using **3.7**

Regards,