### PR TITLE
Fix #180: Server unable to shutdown when persistent connections exist

### DIFF
--- a/uvloop/server.pyx
+++ b/uvloop/server.pyx
@@ -44,7 +44,10 @@ cdef class Server:
 
     @cython.iterable_coroutine
     async def wait_closed(self):
-        if self._waiters is None:
+        # Do not remove `self._servers is None` below
+        # because close() method only closes server sockets
+        # and existing client connections are left open.
+        if self._servers is None or self._waiters is None:
             return
         waiter = self._loop._new_future()
         self._waiters.append(waiter)


### PR DESCRIPTION
Fix #180 

test results with uvloop==0.11.0 (on Python3.7):
```
test_aiohttp_basic_1 (test_aiohttp.Test_AIO_AioHTTP) ... ok
test_aiohttp_graceful_shutdown (test_aiohttp.Test_AIO_AioHTTP) ... ok
test_aiohttp_basic_1 (test_aiohttp.Test_UV_AioHTTP) ... ok
test_aiohttp_graceful_shutdown (test_aiohttp.Test_UV_AioHTTP) ... ERROR
```

After reverting 124e981bc90fbe2814dd1efd051e5b5a394cf1df:
```
...
test_aiohttp_basic_1 (test_aiohttp.Test_AIO_AioHTTP) ... ok
test_aiohttp_graceful_shutdown (test_aiohttp.Test_AIO_AioHTTP) ... ok
test_aiohttp_basic_1 (test_aiohttp.Test_UV_AioHTTP) ... ok
test_aiohttp_graceful_shutdown (test_aiohttp.Test_UV_AioHTTP) ... ok
...
Ran 433 tests in 56.299s

OK (skipped=16)
```