### PR TITLE
Allow UDP to have tp_clear

### DIFF
--- a/uvloop/handles/basetransport.pyx
+++ b/uvloop/handles/basetransport.pyx
@@ -1,4 +1,3 @@
-@cython.no_gc_clear
 cdef class UVBaseTransport(UVSocketHandle):
 
     def __cinit__(self):

--- a/uvloop/handles/handle.pyx
+++ b/uvloop/handles/handle.pyx
@@ -1,4 +1,3 @@
-@cython.no_gc_clear
 cdef class UVHandle:
     """A base class for all libuv handles.
 
@@ -219,7 +218,6 @@ cdef class UVHandle:
             id(self))
 
 
-@cython.no_gc_clear
 cdef class UVSocketHandle(UVHandle):
 
     def __cinit__(self):

--- a/uvloop/handles/udp.pyx
+++ b/uvloop/handles/udp.pyx
@@ -1,4 +1,3 @@
-@cython.no_gc_clear
 cdef class UDPTransport(UVBaseTransport):
 
     def __cinit__(self):


### PR DESCRIPTION
This makes the GC of UDPTransport<->UVPoll pair more deterministic
and avoids a segfault.

Fixes #125.