### PR TITLE
Improve UDPTransport.sendto address validation (fixes: #214)

### DIFF
--- a/uvloop/handles/udp.pxd
+++ b/uvloop/handles/udp.pxd
@@ -1,6 +1,9 @@
 cdef class UDPTransport(UVBaseTransport):
     cdef:
         object sock
+        int sock_family
+        int sock_proto
+        int sock_type
         UVPoll poll
         object address
         object buffer


### PR DESCRIPTION
When UDPTransport.sendto is called with a destination address, only
perform the validation once and store the result in an LRU cache. Also
store some of the socket's properties (family, proto, type) as integers
to avoid repeatedly fetching these properties and converting them to integers.