### PR TITLE
Don't use non-existent UDPTransport._address attribute (fixes: #207)

### DIFF
--- a/tests/test_udp.py
+++ b/tests/test_udp.py
@@ -201,6 +201,19 @@ class Test_UV_UDP(_TestUDP, tb.UVTestCase):
         s_transport.close()
         self.loop.run_until_complete(asyncio.sleep(0.01, loop=self.loop))
 
+    def test_send_after_close(self):
+        coro = self.loop.create_datagram_endpoint(
+            asyncio.DatagramProtocol,
+            local_addr=('127.0.0.1', 0),
+            family=socket.AF_INET)
+
+        s_transport, _ = self.loop.run_until_complete(coro)
+
+        s_transport.close()
+        s_transport.sendto(b'aaaa', ('127.0.0.1', 80))
+        self.loop.run_until_complete(asyncio.sleep(0.01, loop=self.loop))
+        s_transport.sendto(b'aaaa', ('127.0.0.1', 80))
+
 
 class Test_AIO_UDP(_TestUDP, tb.AIOTestCase):
     pass

--- a/uvloop/handles/udp.pyx
+++ b/uvloop/handles/udp.pyx
@@ -165,7 +165,7 @@ cdef class UDPTransport(UVBaseTransport):
             validate_address(addr, self.sock_family, self.sock_type,
                              self.sock_proto)
 
-        if self._conn_lost and self._address:
+        if self._conn_lost:
             if self._conn_lost >= LOG_THRESHOLD_FOR_CONNLOST_WRITES:
                 aio_logger.warning('socket.send() raised exception.')
             self._conn_lost += 1


### PR DESCRIPTION
If the sendto() method is called after closing the transport, it bombs
with an AttributeError as there is no `._address` attribute. Replacing
this by `.address` is not a solution either, as we need to exit in any
case otherwise the call to sendto() bombs again due to `.sock` having
been set to None.