### PR TITLE
Fixes #220 sslproto memory issue

### DIFF
--- a/uvloop/sslproto.pyx
+++ b/uvloop/sslproto.pyx
@@ -341,9 +341,9 @@ cdef class SSLProtocol:
         self._app_transport = None
         self._wakeup_waiter(exc)
 
-        if getattr(self, '_shutdown_timeout_handle', None):
+        if self._shutdown_timeout_handle:
             self._shutdown_timeout_handle.cancel()
-        if getattr(self, '_handshake_timeout_handle', None):
+        if self._handshake_timeout_handle:
             self._handshake_timeout_handle.cancel()
 
     def get_buffer(self, n):
@@ -453,8 +453,13 @@ cdef class SSLProtocol:
         self._set_state(DO_HANDSHAKE)
 
         # start handshake timeout count down
+        # XXX: This is a workaround to call cdef method and clear reference to
+        # self when the handle is cancelled (because uvloop currently clears
+        # only args, it'll be okay to remove the lambda x: x() after the fix to
+        # clear also the callback)
         self._handshake_timeout_handle = \
             self._loop.call_later(self._ssl_handshake_timeout,
+                                  lambda x: x(),
                                   lambda: self._check_handshake_timeout())
 
         try:
@@ -533,8 +538,13 @@ cdef class SSLProtocol:
             self._abort(None)
         else:
             self._set_state(FLUSHING)
+            # XXX: This is a workaround to call cdef method and clear reference
+            # to self when the handle is cancelled (because uvloop currently
+            # clears only args, it'll be okay to remove the lambda x: x() after
+            # the fix to clear also the callback)
             self._shutdown_timeout_handle = \
                 self._loop.call_later(self._ssl_shutdown_timeout,
+                                      lambda x: x(),
                                       lambda: self._check_shutdown_timeout())
             self._do_flush()
 


### PR DESCRIPTION
I think this could at least fix the issue that is reproducible with the given script in #220. In the meantime, I'm still looking for more corner cases that may lead to issues.

- [x] Write tests to cover #220 

Tasks below shall be addressed in a new PR:

- [ ] `SSLTransport` that is never closed by orphaned AppProtocol (shared with asyncio?)
- [ ] uvloop should clear reference to the callback (not just args, new PR)
- [ ] Review all corner cases and write more tests