### PR TITLE
Implement Server.start_serving() and related APIs

### DIFF
--- a/tests/test_unix.py
+++ b/tests/test_unix.py
@@ -66,6 +66,8 @@ class _TestUnix:
                 try:
                     srv_socks = srv.sockets
                     self.assertTrue(srv_socks)
+                    if self.has_start_serving():
+                        self.assertTrue(srv.is_serving())
 
                     tasks = []
                     for _ in range(TOTAL_CNT):
@@ -82,6 +84,9 @@ class _TestUnix:
                     # Check that the server cleaned-up proxy-sockets
                     for srv_sock in srv_socks:
                         self.assertEqual(srv_sock.fileno(), -1)
+
+                    if self.has_start_serving():
+                        self.assertFalse(srv.is_serving())
 
                 # asyncio doesn't cleanup the sock file
                 self.assertTrue(os.path.exists(sock_name))
@@ -100,6 +105,8 @@ class _TestUnix:
                 try:
                     srv_socks = srv.sockets
                     self.assertTrue(srv_socks)
+                    if self.has_start_serving():
+                        self.assertTrue(srv.is_serving())
 
                     tasks = []
                     for _ in range(TOTAL_CNT):
@@ -116,6 +123,9 @@ class _TestUnix:
                     # Check that the server cleaned-up proxy-sockets
                     for srv_sock in srv_socks:
                         self.assertEqual(srv_sock.fileno(), -1)
+
+                    if self.has_start_serving():
+                        self.assertFalse(srv.is_serving())
 
                 # asyncio doesn't cleanup the sock file
                 self.assertTrue(os.path.exists(sock_name))

--- a/uvloop/_testbase.py
+++ b/uvloop/_testbase.py
@@ -67,6 +67,10 @@ class BaseTestCase(unittest.TestCase, metaclass=BaseTestCaseMeta):
     def mock_pattern(self, str):
         return MockPattern(str)
 
+    def has_start_serving(self):
+        return not (self.is_asyncio_loop() and
+                    sys.version_info[:2] in [(3, 5), (3, 6)])
+
     def is_asyncio_loop(self):
         return type(self.loop).__module__.startswith('asyncio.')
 

--- a/uvloop/handles/pipe.pxd
+++ b/uvloop/handles/pipe.pxd
@@ -4,6 +4,7 @@ cdef class UnixServer(UVStreamServer):
 
     @staticmethod
     cdef UnixServer new(Loop loop, object protocol_factory, Server server,
+                        object backlog,
                         object ssl,
                         object ssl_handshake_timeout,
                         object ssl_shutdown_timeout)

--- a/uvloop/handles/pipe.pyx
+++ b/uvloop/handles/pipe.pyx
@@ -38,13 +38,14 @@ cdef class UnixServer(UVStreamServer):
 
     @staticmethod
     cdef UnixServer new(Loop loop, object protocol_factory, Server server,
+                        object backlog,
                         object ssl,
                         object ssl_handshake_timeout,
                         object ssl_shutdown_timeout):
 
         cdef UnixServer handle
         handle = UnixServer.__new__(UnixServer)
-        handle._init(loop, protocol_factory, server,
+        handle._init(loop, protocol_factory, server, backlog,
                      ssl, ssl_handshake_timeout, ssl_shutdown_timeout)
         __pipe_init_uv_handle(<UVStream>handle, loop)
         return handle

--- a/uvloop/handles/streamserver.pxd
+++ b/uvloop/handles/streamserver.pxd
@@ -1,5 +1,6 @@
 cdef class UVStreamServer(UVSocketHandle):
     cdef:
+        int backlog
         object ssl
         object ssl_handshake_timeout
         object ssl_shutdown_timeout
@@ -10,13 +11,15 @@ cdef class UVStreamServer(UVSocketHandle):
     # All "inline" methods are final
 
     cdef inline _init(self, Loop loop, object protocol_factory,
-                      Server server, object ssl,
+                      Server server,
+                      object backlog,
+                      object ssl,
                       object ssl_handshake_timeout,
                       object ssl_shutdown_timeout)
 
     cdef inline _mark_as_open(self)
 
-    cdef inline listen(self, backlog)
+    cdef inline listen(self)
     cdef inline _on_listen(self)
 
     cdef UVStream _make_new_transport(self, object protocol, object waiter)

--- a/uvloop/handles/tcp.pxd
+++ b/uvloop/handles/tcp.pxd
@@ -3,7 +3,9 @@ cdef class TCPServer(UVStreamServer):
 
     @staticmethod
     cdef TCPServer new(Loop loop, object protocol_factory, Server server,
-                       object ssl, unsigned int flags,
+                       unsigned int flags,
+                       object backlog,
+                       object ssl,
                        object ssl_handshake_timeout,
                        object ssl_shutdown_timeout)
 

--- a/uvloop/handles/tcp.pyx
+++ b/uvloop/handles/tcp.pyx
@@ -57,13 +57,15 @@ cdef class TCPServer(UVStreamServer):
 
     @staticmethod
     cdef TCPServer new(Loop loop, object protocol_factory, Server server,
-                       object ssl, unsigned int flags,
+                       unsigned int flags,
+                       object backlog,
+                       object ssl,
                        object ssl_handshake_timeout,
                        object ssl_shutdown_timeout):
 
         cdef TCPServer handle
         handle = TCPServer.__new__(TCPServer)
-        handle._init(loop, protocol_factory, server,
+        handle._init(loop, protocol_factory, server, backlog,
                      ssl, ssl_handshake_timeout, ssl_shutdown_timeout)
         __tcp_init_uv_handle(<UVStream>handle, loop, flags)
         return handle

--- a/uvloop/includes/stdlib.pxi
+++ b/uvloop/includes/stdlib.pxi
@@ -66,6 +66,8 @@ cdef gc_disable = gc.disable
 cdef iter_chain = itertools.chain
 cdef inspect_isgenerator = inspect.isgenerator
 
+cdef int has_IPV6_V6ONLY = hasattr(socket, 'IPV6_V6ONLY')
+cdef int IPV6_V6ONLY = getattr(socket, 'IPV6_V6ONLY', -1)
 cdef int has_SO_REUSEPORT = hasattr(socket, 'SO_REUSEPORT')
 cdef int SO_REUSEPORT = getattr(socket, 'SO_REUSEPORT', 0)
 cdef int SO_BROADCAST = getattr(socket, 'SO_BROADCAST')
@@ -118,6 +120,7 @@ cdef sys_set_coroutine_wrapper = sys.set_coroutine_wrapper
 cdef sys_get_coroutine_wrapper = sys.get_coroutine_wrapper
 cdef sys_getframe = sys._getframe
 cdef sys_version_info = sys.version_info
+cdef str sys_platform = sys.platform
 
 cdef ssl_SSLContext = ssl.SSLContext
 cdef ssl_MemoryBIO = ssl.MemoryBIO

--- a/uvloop/loop.pxd
+++ b/uvloop/loop.pxd
@@ -161,15 +161,6 @@ cdef class Loop:
 
     cdef _getnameinfo(self, system.sockaddr *addr, int flags)
 
-    cdef _create_server(self, system.sockaddr *addr,
-                        object protocol_factory,
-                        Server server,
-                        object ssl,
-                        bint reuse_port,
-                        object backlog,
-                        object ssl_handshake_timeout,
-                        object ssl_shutdown_timeout)
-
     cdef _track_transport(self, UVBaseTransport transport)
     cdef _fileobj_to_fd(self, fileobj)
     cdef _ensure_fd_no_transport(self, fd)

--- a/uvloop/server.pxd
+++ b/uvloop/server.pxd
@@ -4,9 +4,12 @@ cdef class Server:
         list _waiters
         int _active_count
         Loop _loop
+        bint _serving
+        object _serving_forever_fut
         object __weakref__
 
     cdef _add_server(self, UVStreamServer srv)
+    cdef _start_serving(self)
     cdef _wakeup(self)
 
     cdef _attach(self)


### PR DESCRIPTION
This is still work in progress, but I wanted to have some code up so we can start discussing it.

- I have moved `backlog` to a member, so that `listen` (internal API for `start_serving`) can be called without arguments.

- I noticed some argument validation (e.g.: backlog, ssl, ssl_backlog, timeouts) is performed quite deep inside the code, inside `UVStreamServer`. Shouldn't this be done closer to the API surface?

- Currently one test fails because the previous code caught an `OSError` and re-raised it with a different message. Is this a behaviour we want to preserve?

- I'm having trouble understanding the `Server` class, which seem to serve as the user-facing API as opposed to the internal `UVStreamServer` subclasses. The bit that bothers we: why does `Server` have a **list** of servers, can there really be anything other than 0 or 1?

- Who should carry the internal `is_serving` state, the `Server` or the `UVStreamServer`?

- How should we implement the future returned by `serve_forever`?