### PR TITLE
Upgrade to libuv v1.26.0.

### DIFF
--- a/uvloop/handles/pipe.pxd
+++ b/uvloop/handles/pipe.pxd
@@ -27,6 +27,10 @@ cdef class ReadUnixTransport(UVStream):
 
 cdef class WriteUnixTransport(UVStream):
 
+    cdef:
+        uv.uv_poll_t disconnect_listener
+        bint disconnect_listener_inited
+
     @staticmethod
     cdef WriteUnixTransport new(Loop loop, object protocol, Server server,
                                 object waiter)

--- a/uvloop/includes/compat.h
+++ b/uvloop/includes/compat.h
@@ -3,11 +3,6 @@
 #include "uv.h"
 
 
-// uv_poll_event.UV_DISCONNECT is available since libuv v1.9.0
-#if UV_VERSION_HEX < 0x10900
-#define UV_DISCONNECT 0
-#endif
-
 #ifndef EWOULDBLOCK
 #define EWOULDBLOCK EAGAIN
 #endif

--- a/uvloop/includes/uv.pxd
+++ b/uvloop/includes/uv.pxd
@@ -4,12 +4,6 @@ from posix.types cimport gid_t, uid_t
 from . cimport system
 
 
-cdef extern from "includes/compat.h":
-    # Member of uv_poll_event, in compat.h for compatibility
-    # with libuv < v1.9.0
-    cdef int UV_DISCONNECT
-
-
 cdef extern from "uv.h" nogil:
     cdef int UV_TCP_IPV6ONLY
 
@@ -190,7 +184,7 @@ cdef extern from "uv.h" nogil:
     ctypedef enum uv_poll_event:
         UV_READABLE = 1,
         UV_WRITABLE = 2
-        # UV_DISCONNECT = 4 ; see compat.h for details
+        UV_DISCONNECT = 4
 
     ctypedef enum uv_membership:
         UV_LEAVE_GROUP = 0,


### PR DESCRIPTION
That required to change how WriteUnixTransport monitors the pipe for an
EOF event.  Prior to libuv v1.23.1 it was possible to use uv_read_start
for that purpose.  Now we're using a throw away uv_poll_t to monitor for
UV_DISCONNECT.