### PR TITLE
Use travis homebrew add-on to speed up OS X builds

### DIFF
--- a/.ci/travis-install.sh
+++ b/.ci/travis-install.sh
@@ -3,8 +3,6 @@
 set -e -x
 
 if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
-    brew update >/dev/null
-    brew upgrade pyenv
     eval "$(pyenv init -)"
 
     if ! (pyenv versions | grep "${PYTHON_VERSION}$"); then
@@ -12,11 +10,6 @@ if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
     fi
     pyenv global ${PYTHON_VERSION}
     pyenv rehash
-
-    brew install gnu-sed
-    brew outdated libtool || brew upgrade libtool
-    brew outdated autoconf || brew upgrade autoconf
-    brew outdated automake || brew upgrade automake
 fi
 
 pip install --upgrade setuptools pip wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,16 @@ matrix:
           services: [docker]
           env: BUILD=tests,wheels,release
 
+addons:
+    homebrew:
+        packages:
+            - autoconf
+            - automake
+            - gnu-sed
+            - libtool
+            - pyenv
+        update: true
+
 cache:
     pip
 


### PR DESCRIPTION
The OS X builds take a long time upgrading homebrew manually, which can
be avoided by using the "homebrew" add-on.