### PR TITLE
Make Server an asynchronous context manager (fixes: #221)

### DIFF
--- a/tests/test_tcp.py
+++ b/tests/test_tcp.py
@@ -393,14 +393,16 @@ class _TestTCP:
                 loop=self.loop,
                 start_serving=False)
 
-            fut = asyncio.ensure_future(srv.serve_forever(), loop=self.loop)
-            await asyncio.sleep(0, loop=self.loop)
-            self.assertTrue(srv.is_serving())
+            async with srv:
+                fut = asyncio.ensure_future(srv.serve_forever(),
+                                            loop=self.loop)
+                await asyncio.sleep(0, loop=self.loop)
+                self.assertTrue(srv.is_serving())
 
-            fut.cancel()
-            with self.assertRaises(asyncio.CancelledError):
-                await fut
-            self.assertFalse(srv.is_serving())
+                fut.cancel()
+                with self.assertRaises(asyncio.CancelledError):
+                    await fut
+                self.assertFalse(srv.is_serving())
 
         self.loop.run_until_complete(start_server())
 

--- a/uvloop/server.pyx
+++ b/uvloop/server.pyx
@@ -48,6 +48,15 @@ cdef class Server:
 
     # Public API
 
+    @cython.iterable_coroutine
+    async def __aenter__(self):
+        return self
+
+    @cython.iterable_coroutine
+    async def __aexit__(self, *exc):
+        self.close()
+        await self.wait_closed()
+
     def __repr__(self):
         return '<%s sockets=%r>' % (self.__class__.__name__, self.sockets)
 


### PR DESCRIPTION
The Server class was missing `__aenter__` and `__aexit__` magic methods to
allow usage of the form:

```
  async with server:
    await server.serve_forever()
```