### PR TITLE
Fix SSL memory leak

### DIFF
--- a/tests/test_tcp.py
+++ b/tests/test_tcp.py
@@ -1724,6 +1724,72 @@ class _TestSSL(tb.SSLTestCase):
             self.loop.run_until_complete(
                 asyncio.wait_for(client(srv.addr), loop=self.loop, timeout=10))
 
+    def test_create_connection_memory_leak(self):
+        if self.implementation == 'asyncio':
+            raise unittest.SkipTest()
+
+        HELLO_MSG = b'1' * self.PAYLOAD_SIZE
+
+        server_context = self._create_server_ssl_context(
+            self.ONLYCERT, self.ONLYKEY)
+        client_context = self._create_client_ssl_context()
+
+        def serve(sock):
+            sock.settimeout(self.TIMEOUT)
+
+            sock.starttls(server_context, server_side=True)
+
+            sock.sendall(b'O')
+            data = sock.recv_all(len(HELLO_MSG))
+            self.assertEqual(len(data), len(HELLO_MSG))
+
+            sock.unwrap()
+            sock.close()
+
+        class ClientProto(asyncio.Protocol):
+            def __init__(self, on_data, on_eof):
+                self.on_data = on_data
+                self.on_eof = on_eof
+                self.con_made_cnt = 0
+
+            def connection_made(proto, tr):
+                # XXX: We assume user stores the transport in protocol
+                proto.tr = tr
+                proto.con_made_cnt += 1
+                # Ensure connection_made gets called only once.
+                self.assertEqual(proto.con_made_cnt, 1)
+
+            def data_received(self, data):
+                self.on_data.set_result(data)
+
+            def eof_received(self):
+                self.on_eof.set_result(True)
+
+        async def client(addr):
+            await asyncio.sleep(0.5, loop=self.loop)
+
+            on_data = self.loop.create_future()
+            on_eof = self.loop.create_future()
+
+            tr, proto = await self.loop.create_connection(
+                lambda: ClientProto(on_data, on_eof), *addr,
+                ssl=client_context)
+
+            self.assertEqual(await on_data, b'O')
+            tr.write(HELLO_MSG)
+            await on_eof
+
+            tr.close()
+
+        with self.tcp_server(serve, timeout=self.TIMEOUT) as srv:
+            self.loop.run_until_complete(
+                asyncio.wait_for(client(srv.addr), loop=self.loop, timeout=10))
+
+        # No garbage is left for SSL client from loop.create_connection, even
+        # if user stores the SSLTransport in corresponding protocol instance
+        client_context = weakref.ref(client_context)
+        self.assertIsNone(client_context())
+
     def test_start_tls_client_buf_proto_1(self):
         if self.implementation == 'asyncio':
             raise unittest.SkipTest()

--- a/uvloop/sslproto.pyx
+++ b/uvloop/sslproto.pyx
@@ -339,6 +339,7 @@ cdef class SSLProtocol:
         self._set_state(UNWRAPPED)
         self._transport = None
         self._app_transport = None
+        self._app_protocol = None
         self._wakeup_waiter(exc)
 
         if self._shutdown_timeout_handle:


### PR DESCRIPTION
Refs [bpo-34745](https://bugs.python.org/issue34745), protocol and transport form circular reference, causing `SSLContext` stack up ugly.

Before the fix:

![bpo2-uvloop-issue](https://user-images.githubusercontent.com/1751601/54493303-65b57680-489c-11e9-9609-45f83dd7e607.png)

After the fix:

![bpo2-uvloop-fixed](https://user-images.githubusercontent.com/1751601/54493306-6b12c100-489c-11e9-92b5-36ab03f0daba.png)

The script to test:
```python
import asyncio
import logging
import ssl
import socket
import sys
import uvloop

CREDENTIAL = ""

URLS = {
    "https://s3.us-west-2.amazonaws.com/archpi.dabase.com/style.css": {
        "method": "get",
        "headers": {
            "User-Agent": "Botocore/1.8.21 Python/3.6.4 Darwin/17.5.0",
            "X-Amz-Date": "20180518T025044Z",
            "X-Amz-Content-SHA256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
            "Authorization": f"AWS4-HMAC-SHA256 Credential={CREDENTIAL}/20180518/us-west-2/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=ae552641b9aa9a7a267fcb4e36960cd5863e55d91c9b45fd39b30fdcd2e81489",
            "Accept-Encoding": "identity",
        },
    },
    "https://s3.ap-southeast-1.amazonaws.com/archpi.dabase.com/doesnotexist": {
        "method": "GET" if sys.argv[1] == "get_object" else "HEAD",
        "headers": {
            "User-Agent": "Botocore/1.8.21 Python/3.6.4 Darwin/17.5.0",
            "X-Amz-Date": "20180518T025221Z",
            "X-Amz-Content-SHA256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
            "Authorization": f"AWS4-HMAC-SHA256 Credential={CREDENTIAL}/20180518/ap-southeast-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=7a7675ef6d70cb647ed59e02d532ffa80d437fb03976d8246ea9ef102d118794",
            "Accept-Encoding": "identity",
        },
    },
}

asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())


class HttpClient(asyncio.streams.FlowControlMixin):
    transport = None

    def __init__(self, *args, **kwargs):
        self.__url = kwargs.pop("url")
        self.__logger = logging.getLogger()
        super().__init__()

    def connection_made(self, transport):
        self.transport = transport

        entry = URLS[self.__url]

        body = "HEAD /archpi.dabase.com/doesnotexist HTTP/1.1\r\nAccept: */*\r\nHost: s3.ap-southeast-1.amazonaws.com\r\n"
        for name, value in entry["headers"].items():
            body += f"{name}: {value}\r\n"

        body += "\r\n"
        self.transport.write(body.encode("ascii"))
        self.__logger.info(f'data sent: {body}')

    def data_received(self, data):
        self.__logger.info(f'data received: {data}')

        self.transport.close()
        # asyncio.get_event_loop().call_later(1.0, )

    def eof_received(self):
        self.__logger.info('eof_received')

    def connection_lost(self, exc):
        self.__logger.info(f'connection lost: {exc}')
        super().connection_lost(exc)

    @classmethod
    def create_factory(cls, url: str):
        def factory(*args, **kwargs):
            return cls(*args, url=url, **kwargs)

        return factory


async def test_asyncio(ssl_context):
    loop = asyncio.get_event_loop()

    url = "https://s3.ap-southeast-1.amazonaws.com/archpi.dabase.com/doesnotexist"
    port = 443
    host = "s3.ap-southeast-1.amazonaws.com"
    infos = await loop.getaddrinfo(host, port, family=socket.AF_INET)
    family, type, proto, canonname, sockaddr = infos[0]
    await loop.create_connection(
        HttpClient.create_factory(url),
        sockaddr[0],
        port,
        ssl=ssl_context,
        family=family,
        proto=proto,
        flags=socket.AI_NUMERICHOST,
        server_hostname=host,
        local_addr=None,
    )


async def asyncio_test():
    ssl_context = ssl.create_default_context()

    while True:
        await test_asyncio(ssl_context)


def main():
    print("running")
    loop = asyncio.get_event_loop()
    for i in range(16):
        loop.create_task(asyncio_test())
    loop.run_forever()


main()
```