### PR TITLE
Fix memory leak related to call_later() and call_at()

### DIFF
--- a/uvloop/cbhandles.pxd
+++ b/uvloop/cbhandles.pxd
@@ -24,14 +24,14 @@ cdef class Handle:
 
 cdef class TimerHandle:
     cdef:
-        object callback, args
+        object callback
+        tuple args
         bint _cancelled
         UVTimer timer
         Loop loop
         object context
+        tuple _debug_info
         object __weakref__
-
-        readonly _source_traceback
 
     cdef _run(self)
     cdef _cancel(self)


### PR DESCRIPTION
The crux of the problem is that TimerHandle did not clean up a strong
reference from the event loop to `self`.  This typically isn't a problem
unless there's another strong reference to the loop from the callback or
from its arguments (such as a Future).

A few new unit tests should ensure this kind of bugs won't happen again.

Fixes: #239.