### PR TITLE
enforce TLS<1.3 for SSL renegotiation tests

### DIFF
--- a/tests/test_tcp.py
+++ b/tests/test_tcp.py
@@ -2203,6 +2203,8 @@ class _TestSSL(tb.SSLTestCase):
         sslctx.use_privatekey_file(self.ONLYKEY)
         sslctx.use_certificate_chain_file(self.ONLYCERT)
         client_sslctx = self._create_client_ssl_context()
+        if hasattr(ssl, 'OP_NO_TLSv1_3'):
+            client_sslctx.options |= ssl.OP_NO_TLSv1_3
 
         def server(sock):
             conn = openssl_ssl.Connection(sslctx, sock)
@@ -2560,6 +2562,8 @@ class _TestSSL(tb.SSLTestCase):
         sslctx_openssl.use_privatekey_file(self.ONLYKEY)
         sslctx_openssl.use_certificate_chain_file(self.ONLYCERT)
         client_sslctx = self._create_client_ssl_context()
+        if hasattr(ssl, 'OP_NO_TLSv1_3'):
+            client_sslctx.options |= ssl.OP_NO_TLSv1_3
 
         future = None
 


### PR DESCRIPTION
In new versions of PyOpenSSL, it seems insufficient to use `openssl_ssl.Context(openssl_ssl.SSLv23_METHOD)` to have TLS < 1.3. As the `OP_NO_TLSv1_3` may not always exist in PyOpenSSL, we just use the one from CPython on the client side.
* fixes #248 