### PR TITLE
sys.set_coroutine_wrapper is removed in Python 3.8

### DIFF
--- a/uvloop/includes/stdlib.pxi
+++ b/uvloop/includes/stdlib.pxi
@@ -116,8 +116,8 @@ cdef stat_S_ISSOCK = stat.S_ISSOCK
 
 cdef sys_ignore_environment = sys.flags.ignore_environment
 cdef sys_exc_info = sys.exc_info
-cdef sys_set_coroutine_wrapper = sys.set_coroutine_wrapper
-cdef sys_get_coroutine_wrapper = sys.get_coroutine_wrapper
+cdef sys_set_coroutine_wrapper = getattr(sys, 'set_coroutine_wrapper', None)
+cdef sys_get_coroutine_wrapper = getattr(sys, 'get_coroutine_wrapper', None)
 cdef sys_getframe = sys._getframe
 cdef sys_version_info = sys.version_info
 cdef sys_getfilesystemencoding = sys.getfilesystemencoding


### PR DESCRIPTION
The functions `sys.set_coroutine_wrapper` and `sys.get_coroutine_wrapper`,
which were provisionally added to Python 3.5 and deprecated in Python 3.7,
are removed in Python 3.8.

uvloop doesn't use them since Python 3.7, but they remained defined
in stdlib.pxi, leading to AttributeErrors on Python 3.8+.

This makes the definition fallback to None if such functions don't exist.

Fixes https://github.com/MagicStack/uvloop/issues/251