### PR TITLE
add app state check

### DIFF
--- a/uvloop/sslproto.pxd
+++ b/uvloop/sslproto.pxd
@@ -6,6 +6,20 @@ cdef enum SSLProtocolState:
     SHUTDOWN = 4
 
 
+cdef enum AppProtocolState:
+    # This tracks the state of app protocol (https://git.io/fj59P):
+    #     start -> CM [-> DR*] [-> ER?] -> CL -> end
+    # * CM: connection_made()
+    # * DR: data_received()
+    # * ER: eof_received()
+    # * CL: connection_lost()
+
+    START = 0
+    AFTER_CM = 1
+    AFTER_ER = 2
+    END = 3
+
+
 cdef class _SSLProtocolTransport:
     cdef:
         object _loop
@@ -30,7 +44,6 @@ cdef class SSLProtocol:
         bint _app_transport_created
 
         object _transport
-        bint _call_connection_made
         object _ssl_handshake_timeout
         object _ssl_shutdown_timeout
 
@@ -46,7 +59,7 @@ cdef class SSLProtocol:
         object _ssl_buffer_view
         SSLProtocolState _state
         size_t _conn_lost
-        bint _eof_received
+        AppProtocolState _app_state
 
         bint _ssl_writing_paused
         bint _app_reading_paused

--- a/uvloop/sslproto.pxd
+++ b/uvloop/sslproto.pxd
@@ -8,16 +8,18 @@ cdef enum SSLProtocolState:
 
 cdef enum AppProtocolState:
     # This tracks the state of app protocol (https://git.io/fj59P):
-    #     start -> CM [-> DR*] [-> ER?] -> CL -> end
-    # * CM: connection_made()
-    # * DR: data_received()
-    # * ER: eof_received()
-    # * CL: connection_lost()
+    #
+    #     INIT -cm-> CON_MADE [-dr*->] [-er-> EOF?] -cl-> CON_LOST
+    #
+    # * cm: connection_made()
+    # * dr: data_received()
+    # * er: eof_received()
+    # * cl: connection_lost()
 
-    START = 0
-    AFTER_CM = 1
-    AFTER_ER = 2
-    END = 3
+    STATE_INIT = 0
+    STATE_CON_MADE = 1
+    STATE_EOF = 2
+    STATE_CON_LOST = 3
 
 
 cdef class _SSLProtocolTransport:

--- a/uvloop/sslproto.pyx
+++ b/uvloop/sslproto.pyx
@@ -253,7 +253,6 @@ cdef class SSLProtocol:
         self._app_transport_created = False
         # transport, ex: SelectorSocketTransport
         self._transport = None
-        self._call_connection_made = call_connection_made
         self._ssl_handshake_timeout = ssl_handshake_timeout
         self._ssl_shutdown_timeout = ssl_shutdown_timeout
         # SSL and state machine
@@ -264,7 +263,7 @@ cdef class SSLProtocol:
         self._outgoing_read = self._outgoing.read
         self._state = UNWRAPPED
         self._conn_lost = 0  # Set when connection_lost called
-        self._eof_received = False
+        self._app_state = START if call_connection_made else AFTER_CM
 
         # Flow Control
 
@@ -335,7 +334,9 @@ cdef class SSLProtocol:
             self._app_transport._closed = True
 
         if self._state != DO_HANDSHAKE:
-            self._loop.call_soon(self._app_protocol.connection_lost, exc)
+            if self._app_state == AFTER_CM or self._app_state == AFTER_ER:
+                self._app_state = END
+                self._loop.call_soon(self._app_protocol.connection_lost, exc)
         self._set_state(UNWRAPPED)
         self._transport = None
         self._app_transport = None
@@ -518,7 +519,8 @@ cdef class SSLProtocol:
                            cipher=sslobj.cipher(),
                            compression=sslobj.compression(),
                            ssl_object=sslobj)
-        if self._call_connection_made:
+        if self._app_state == START:
+            self._app_state = AFTER_CM
             self._app_protocol.connection_made(self._get_app_transport())
         self._wakeup_waiter()
         self._do_read()
@@ -735,8 +737,8 @@ cdef class SSLProtocol:
 
     cdef _call_eof_received(self):
         try:
-            if not self._eof_received:
-                self._eof_received = True
+            if self._app_state == AFTER_CM:
+                self._app_state = AFTER_ER
                 keep_open = self._app_protocol.eof_received()
                 if keep_open:
                     aio_logger.warning('returning true from eof_received() '


### PR DESCRIPTION
* fixes #246 

`app_state` check is not added at `data_received()` and friends because I think it's too much penalty to raise errors and break connections, even though it should never happen. But please feel free to vote oppositely.

![AIO State](https://user-images.githubusercontent.com/1751601/63616559-6c63ba80-c5ad-11e9-9ba8-0acd64aa32b8.png)

- [x] write tests