### PR TITLE
Restore wakeup_fd if it was updated in _recv_signals_start

### DIFF
--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -275,6 +275,46 @@ finally:
         with self.assertRaisesRegex(TypeError, 'coroutines cannot be used'):
             self.loop.add_signal_handler(signal.SIGHUP, coro)
 
+    def test_wakeup_fd_unchanged(self):
+        async def runner():
+            PROG = R"""\
+import uvloop
+import signal
+import asyncio
+
+
+def get_wakeup_fd():
+    fd = signal.set_wakeup_fd(-1)
+    signal.set_wakeup_fd(fd)
+    return fd
+
+async def f(): pass
+
+fd0 = get_wakeup_fd()
+loop = """ + self.NEW_LOOP + """
+try:
+    asyncio.set_event_loop(loop)
+    loop.run_until_complete(f())
+    fd1 = get_wakeup_fd()
+finally:
+    loop.close()
+
+print(fd0 == fd1, flush=True)
+
+"""
+
+            proc = await asyncio.create_subprocess_exec(
+                sys.executable, b'-W', b'ignore', b'-c', PROG,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                loop=self.loop)
+
+            out, err = await proc.communicate()
+            self.assertEqual(err, b'')
+            self.assertIn(b'True', out)
+
+        self.loop.run_until_complete(runner())
+
 
 class Test_UV_Signals(_TestSignal, tb.UVTestCase):
     NEW_LOOP = 'uvloop.new_event_loop()'

--- a/uvloop/loop.pyx
+++ b/uvloop/loop.pyx
@@ -241,6 +241,8 @@ cdef class Loop:
         self._debug_exception_handler_cnt = 0
 
     cdef _setup_signals(self):
+        cdef int old_wakeup_fd
+
         if self._listening_signals:
             return
 
@@ -248,7 +250,7 @@ cdef class Loop:
         self._ssock.setblocking(False)
         self._csock.setblocking(False)
         try:
-            _set_signal_wakeup_fd(self._csock.fileno())
+            old_wakeup_fd = _set_signal_wakeup_fd(self._csock.fileno())
         except (OSError, ValueError):
             # Not the main thread
             self._ssock.close()
@@ -257,10 +259,12 @@ cdef class Loop:
             return
 
         self._listening_signals = True
+        return old_wakeup_fd
 
     cdef _recv_signals_start(self):
+        cdef object old_wakeup_fd = None
         if self._ssock is None:
-            self._setup_signals()
+            old_wakeup_fd = self._setup_signals()
             if self._ssock is None:
                 # Not the main thread.
                 return
@@ -272,6 +276,7 @@ cdef class Loop:
                 "Loop._read_from_self",
                 <method_t>self._read_from_self,
                 self))
+        return old_wakeup_fd
 
     cdef _recv_signals_stop(self):
         if self._ssock is None:
@@ -445,6 +450,7 @@ cdef class Loop:
 
     cdef _run(self, uv.uv_run_mode mode):
         cdef int err
+        cdef object old_wakeup_fd
 
         if self._closed == 1:
             raise RuntimeError('unable to start the loop; it was closed')
@@ -467,7 +473,7 @@ cdef class Loop:
         self.handler_check__exec_writes.start()
         self.handler_idle.start()
 
-        self._recv_signals_start()
+        old_wakeup_fd = self._recv_signals_start()
 
         if aio_set_running_loop is not None:
             aio_set_running_loop(self)
@@ -478,6 +484,8 @@ cdef class Loop:
                 aio_set_running_loop(None)
 
             self._recv_signals_stop()
+            if old_wakeup_fd is not None:
+                signal_set_wakeup_fd(old_wakeup_fd)
 
             self.handler_check__exec_writes.stop()
             self.handler_idle.stop()
@@ -3164,9 +3172,9 @@ cdef __install_pymem():
 
 cdef _set_signal_wakeup_fd(fd):
     if PY37 and fd >= 0:
-        signal_set_wakeup_fd(fd, warn_on_full_buffer=False)
+        return signal_set_wakeup_fd(fd, warn_on_full_buffer=False)
     else:
-        signal_set_wakeup_fd(fd)
+        return signal_set_wakeup_fd(fd)
 
 
 cdef _warn_with_source(msg, cls, source):


### PR DESCRIPTION
Common behavior for event loops bundled with CPython: they call `signal.set_wakeup_fd` with event loop's pipe descriptor in `add_signal_handler` so if no signal handlers were added - wakeup fd is not modified. UVLoop works differently and eagerly sets wakeup fd inside `_recv_signals_start` called from `run` to make sure that default signal handlers will be invoked. In general this difference does not cause any problems however for some corner cases it becomes an issue. 

As an example: during migration of the large codebase to asyncio sometimes it is hard to convert the entire callstack from sync to async (i.e. because code in question is invoked from some library bits that are not yet async friendly). In order to do this we create nested event loops to start async calls from sync functions and wait for  their completion. That works reasonably well, however in case if top level event loop sets up signal handler (and thus sets its self pipe as `wakeup_fd`) and then somewhere down the stack nested uvloop is created (with no signal handlers attached) - its self pipe overwrites the `wakeup_fd` so top level event loop will never receive the signal. For in-house event loops this issue does not occur because they don't eagerly set `wakeup_fd`.

This PR brings behavior of UVLoop a bit closer to asyncio event loops by restoring `wakeup_fd` if it was changed eagerly.