### PR TITLE
Update Cython for 3.8 compatibility

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,4 @@
-Cython==0.29.10
+Cython==0.29.13
 Sphinx>=1.4.1
 psutil
 pyOpenSSL==18.0.0


### PR DESCRIPTION
Maybe this solves https://github.com/MagicStack/uvloop/issues/266?