### PR TITLE
Prefer PROTOCOL_TLS than PROTOCOL_SSLv23

### DIFF
--- a/examples/bench/echoclient.py
+++ b/examples/bench/echoclient.py
@@ -29,7 +29,10 @@ if __name__ == '__main__':
     client_context = None
     if args.ssl:
         print('with SSL')
-        client_context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+        if hasattr(ssl, 'PROTOCOL_TLS'):
+            client_context = ssl.SSLContext(ssl.PROTOCOL_TLS)
+        else:
+            client_context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
         if hasattr(client_context, 'check_hostname'):
             client_context.check_hostname = False
         client_context.verify_mode = ssl.CERT_NONE

--- a/examples/bench/echoserver.py
+++ b/examples/bench/echoserver.py
@@ -143,7 +143,10 @@ if __name__ == '__main__':
     server_context = None
     if args.ssl:
         print('with SSL')
-        server_context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+        if hasattr(ssl, 'PROTOCOL_TLS'):
+            server_context = ssl.SSLContext(ssl.PROTOCOL_TLS)
+        else:
+            server_context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
         server_context.load_cert_chain(
             (pathlib.Path(__file__).parent.parent.parent /
                 'tests' / 'certs' / 'ssl_cert.pem'),

--- a/tests/test_tcp.py
+++ b/tests/test_tcp.py
@@ -1651,13 +1651,17 @@ class _TestSSL(tb.SSLTestCase):
             self.fail("unexpected call to connection_made()")
 
     def test_ssl_connect_accepted_socket(self):
-        server_context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+        if hasattr(ssl, 'PROTOCOL_TLS'):
+            proto = ssl.PROTOCOL_TLS
+        else:
+            proto = ssl.PROTOCOL_SSLv23
+        server_context = ssl.SSLContext(proto)
         server_context.load_cert_chain(self.ONLYCERT, self.ONLYKEY)
         if hasattr(server_context, 'check_hostname'):
             server_context.check_hostname = False
         server_context.verify_mode = ssl.CERT_NONE
 
-        client_context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+        client_context = ssl.SSLContext(proto)
         if hasattr(server_context, 'check_hostname'):
             client_context.check_hostname = False
         client_context.verify_mode = ssl.CERT_NONE

--- a/uvloop/_testbase.py
+++ b/uvloop/_testbase.py
@@ -271,7 +271,10 @@ def find_free_port(start_from=50000):
 class SSLTestCase:
 
     def _create_server_ssl_context(self, certfile, keyfile=None):
-        sslcontext = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+        if hasattr(ssl, 'PROTOCOL_TLS'):
+            sslcontext = ssl.SSLContext(ssl.PROTOCOL_TLS)
+        else:
+            sslcontext = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
         sslcontext.options |= ssl.OP_NO_SSLv2
         sslcontext.load_cert_chain(certfile, keyfile)
         return sslcontext


### PR DESCRIPTION
Use `PROTOCOL_TLS` whenever possible (Python >= 3.5.3).

* refs #280 

- [x] pass tests