### PR TITLE
Wakeup the waiter with exception if handshake fails

### DIFF
--- a/uvloop/sslproto.pyx
+++ b/uvloop/sslproto.pyx
@@ -522,6 +522,7 @@ cdef class SSLProtocol:
             else:
                 msg = 'SSL handshake failed'
             self._fatal_error(exc, msg)
+            self._wakeup_waiter(exc)
             return
 
         if self._loop.get_debug():


### PR DESCRIPTION
During the work on https://github.com/python/cpython/pull/17975 I've found a minor bug in uvloop: when SSL handshake fails with an exception the waiter is not waked up; it leads to hanging.

I have no idea how to write a test for it; in asyncio we had mocked test already for `eof_received()` during SSL handshaking. As I see EOF is the only scenario that can hang; there is a very low chance that a peer will call `shutdown(sock, SHUT_WR)` on own side without immediate `close(sock)` at least.

Anyway, please merge if you have no objections.