### PR TITLE
Stop using `loop` kwarg in `asyncio.wait()` call (DeprecationWarning)

### DIFF
--- a/uvloop/handles/process.pyx
+++ b/uvloop/handles/process.pyx
@@ -604,7 +604,7 @@ cdef class UVProcessTransport(UVProcess):
 
         if handle._init_futs:
             handle._stdio_ready = 0
-            init_fut = aio_gather(*handle._init_futs, loop=loop)
+            init_fut = aio_gather(*handle._init_futs)
             init_fut.add_done_callback(
                 ft_partial(handle.__stdio_inited, waiter))
         else:

--- a/uvloop/loop.pyx
+++ b/uvloop/loop.pyx
@@ -1908,7 +1908,7 @@ cdef class Loop:
                     lai = &lai_static
 
             if len(fs):
-                await aio_wait(fs, loop=self)
+                await aio_wait(fs)
 
             if rai is NULL:
                 ai_remote = f1.result()

--- a/uvloop/loop.pyx
+++ b/uvloop/loop.pyx
@@ -1682,7 +1682,7 @@ cdef class Loop:
                                     uv.SOCK_STREAM, 0, flags,
                                     0) for host in hosts]
 
-            infos = await aio_gather(*fs, loop=self)
+            infos = await aio_gather(*fs)
 
             completed = False
             sock = None
@@ -3095,8 +3095,7 @@ cdef class Loop:
 
         shutdown_coro = aio_gather(
             *[ag.aclose() for ag in closing_agens],
-            return_exceptions=True,
-            loop=self)
+            return_exceptions=True)
 
         results = await shutdown_coro
         for result, agen in zip(results, closing_agens):


### PR DESCRIPTION
Calling `loop.create_connection()` currently causes Python to send `DeprecationWarning`, this PR solves it.

// edit: I also removed use of `loop` kwarg in `aio_gather` calls
// edit2: Fixes #314 