### PR TITLE
Accept path-like subprocess args (Python 3.8 compatibility)

### DIFF
--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -135,6 +135,21 @@ class _TestProcess:
 
         self.loop.run_until_complete(test())
 
+    @unittest.skipIf(sys.version_info < (3, 8, 0),
+                     "3.5 to 3.7 does not support path-like objects "
+                     "in the asyncio subprocess API")
+    def test_process_executable_2(self):
+        async def test():
+            proc = await asyncio.create_subprocess_exec(
+                pathlib.Path(sys.executable),
+                b'-W', b'ignore', b'-c', b'print("spam")',
+                stdout=subprocess.PIPE)
+
+            out, err = await proc.communicate()
+            self.assertEqual(out, b'spam\n')
+
+        self.loop.run_until_complete(test())
+
     def test_process_pid_1(self):
         async def test():
             prog = '''\

--- a/uvloop/handles/process.pyx
+++ b/uvloop/handles/process.pyx
@@ -284,6 +284,13 @@ cdef class UVProcess(UVHandle):
         self.__args = args.copy()
         for i in range(an):
             arg = args[i]
+            try:
+                fspath = type(arg).__fspath__
+            except AttributeError:
+                pass
+            else:
+                arg = fspath(arg)
+
             if isinstance(arg, str):
                 self.__args[i] = PyUnicode_EncodeFSDefault(arg)
             elif not isinstance(arg, bytes):


### PR DESCRIPTION
This PR resolves #328.