### PR TITLE
Don't stop the loop in `run_until_complete()` on `SystemExit` and `KeyboardInterrupt` exceptions

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -369,21 +369,16 @@ class _TestBase:
 
         self.loop._process_events = mock.Mock()
 
-        try:
+        with self.assertRaises(KeyboardInterrupt):
             self.loop.run_until_complete(raise_keyboard_interrupt())
-        except KeyboardInterrupt:
-            pass
 
         def func():
             self.loop.stop()
             func.called = True
 
         func.called = False
-        try:
-            self.loop.call_soon(func)
-            self.loop.run_forever()
-        except KeyboardInterrupt:
-            pass
+        self.loop.call_later(0.01, func)
+        self.loop.run_forever()
         self.assertTrue(func.called)
 
     def test_debug_slow_callbacks(self):


### PR DESCRIPTION
Fixes #336 