### PR TITLE
Accept empty addr in UDP on_receive

### DIFF
--- a/uvloop/handles/udp.pyx
+++ b/uvloop/handles/udp.pyx
@@ -344,6 +344,12 @@ cdef void __uv_udp_on_receive(uv.uv_udp_t* handle,
 
     if addr is NULL:
         pyaddr = None
+    elif addr.sa_family == uv.AF_UNSPEC:
+        # https://github.com/MagicStack/uvloop/issues/304
+        IF UNAME_SYSNAME == "Linux":
+            pyaddr = None
+        ELSE:
+            pyaddr = ''
     else:
         try:
             pyaddr = __convert_sockaddr_to_pyaddr(addr)
@@ -354,13 +360,6 @@ cdef void __uv_udp_on_receive(uv.uv_udp_t* handle,
     if nread < 0:
         exc = convert_error(nread)
         udp._on_receive(None, exc, pyaddr)
-        return
-
-    if pyaddr is None:
-        udp._fatal_error(
-            RuntimeError(
-                'uv_udp.receive callback: addr is NULL and nread >= 0'),
-            False)
         return
 
     if nread == 0:


### PR DESCRIPTION
* Fixes #304

As per #304, Linux is not setting `msg_name` for receiving from e.g. UDP socket pair. CPython and asyncio will parse the peer address into `None`. However on macOS, `msg_name` is set to a `AF_UNIX` `sockaddr` correctly, so the peer address is an empty string `""`. This PR tries to maintain the same behavior as CPython asyncio.