### PR TITLE
Fix context in protocol callbacks

### DIFF
--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -2,9 +2,21 @@ import asyncio
 import contextvars
 import decimal
 import random
+import socket
 import weakref
 
 from uvloop import _testbase as tb
+
+
+class _Protocol(asyncio.Protocol):
+    def __init__(self, *, loop=None):
+        self.done = asyncio.Future(loop=loop)
+
+    def connection_lost(self, exc):
+        if exc is None:
+            self.done.set_result(None)
+        else:
+            self.done.set_exception(exc)
 
 
 class _ContextBaseTests:
@@ -125,6 +137,40 @@ class _ContextBaseTests:
 
         del tracked
         self.assertIsNone(ref())
+
+    def test_create_server_protocol_factory_context(self):
+        cvar = contextvars.ContextVar('cvar', default='outer')
+        factory_called_future = self.loop.create_future()
+        proto = _Protocol(loop=self.loop)
+
+        def factory():
+            try:
+                self.assertEqual(cvar.get(), 'inner')
+            except Exception as e:
+                factory_called_future.set_exception(e)
+            else:
+                factory_called_future.set_result(None)
+
+            return proto
+
+        async def test():
+            cvar.set('inner')
+            port = tb.find_free_port()
+            srv = await self.loop.create_server(factory, '127.0.0.1', port)
+
+            s = socket.socket(socket.AF_INET)
+            with s:
+                s.setblocking(False)
+                await self.loop.sock_connect(s, ('127.0.0.1', port))
+
+            try:
+                await factory_called_future
+            finally:
+                srv.close()
+                await proto.done
+                await srv.wait_closed()
+
+        self.loop.run_until_complete(test())
 
 
 class Test_UV_Context(_ContextBaseTests, tb.UVTestCase):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,25 +1,150 @@
 import asyncio
 import contextvars
 import decimal
+import itertools
 import random
 import socket
+import ssl
+import tempfile
+import unittest
 import weakref
 
 from uvloop import _testbase as tb
+from tests.test_process import _AsyncioTests
 
 
-class _Protocol(asyncio.Protocol):
-    def __init__(self, *, loop=None):
+class _BaseProtocol(asyncio.BaseProtocol):
+    def __init__(self, cvar, *, loop=None):
+        self.cvar = cvar
+        self.transport = None
+        self.connection_made_fut = asyncio.Future(loop=loop)
+        self.buffered_ctx = None
+        self.data_received_fut = asyncio.Future(loop=loop)
+        self.eof_received_fut = asyncio.Future(loop=loop)
+        self.pause_writing_fut = asyncio.Future(loop=loop)
+        self.resume_writing_fut = asyncio.Future(loop=loop)
+        self.pipe_ctx = {0, 1, 2}
+        self.pipe_connection_lost_fut = asyncio.Future(loop=loop)
+        self.process_exited_fut = asyncio.Future(loop=loop)
+        self.error_received_fut = asyncio.Future(loop=loop)
+        self.connection_lost_ctx = None
         self.done = asyncio.Future(loop=loop)
 
+    def connection_made(self, transport):
+        self.transport = transport
+        self.connection_made_fut.set_result(self.cvar.get())
+
     def connection_lost(self, exc):
+        self.connection_lost_ctx = self.cvar.get()
         if exc is None:
             self.done.set_result(None)
         else:
             self.done.set_exception(exc)
 
+    def eof_received(self):
+        self.eof_received_fut.set_result(self.cvar.get())
 
-class _ContextBaseTests:
+    def pause_writing(self):
+        self.pause_writing_fut.set_result(self.cvar.get())
+
+    def resume_writing(self):
+        self.resume_writing_fut.set_result(self.cvar.get())
+
+
+class _Protocol(_BaseProtocol, asyncio.Protocol):
+    def data_received(self, data):
+        self.data_received_fut.set_result(self.cvar.get())
+
+
+class _BufferedProtocol(_BaseProtocol, asyncio.BufferedProtocol):
+    def get_buffer(self, sizehint):
+        if self.buffered_ctx is None:
+            self.buffered_ctx = self.cvar.get()
+        elif self.cvar.get() != self.buffered_ctx:
+            self.data_received_fut.set_exception(ValueError("{} != {}".format(
+                self.buffered_ctx, self.cvar.get(),
+            )))
+        return bytearray(65536)
+
+    def buffer_updated(self, nbytes):
+        if not self.data_received_fut.done():
+            if self.cvar.get() == self.buffered_ctx:
+                self.data_received_fut.set_result(self.cvar.get())
+            else:
+                self.data_received_fut.set_exception(
+                    ValueError("{} != {}".format(
+                        self.buffered_ctx, self.cvar.get(),
+                    ))
+                )
+
+
+class _DatagramProtocol(_BaseProtocol, asyncio.DatagramProtocol):
+    def datagram_received(self, data, addr):
+        self.data_received_fut.set_result(self.cvar.get())
+
+    def error_received(self, exc):
+        self.error_received_fut.set_result(self.cvar.get())
+
+
+class _SubprocessProtocol(_BaseProtocol, asyncio.SubprocessProtocol):
+    def pipe_data_received(self, fd, data):
+        self.data_received_fut.set_result(self.cvar.get())
+
+    def pipe_connection_lost(self, fd, exc):
+        self.pipe_ctx.remove(fd)
+        val = self.cvar.get()
+        self.pipe_ctx.add(val)
+        if not any(isinstance(x, int) for x in self.pipe_ctx):
+            if len(self.pipe_ctx) == 1:
+                self.pipe_connection_lost_fut.set_result(val)
+            else:
+                self.pipe_connection_lost_fut.set_exception(
+                    AssertionError(str(list(self.pipe_ctx))))
+
+    def process_exited(self):
+        self.process_exited_fut.set_result(self.cvar.get())
+
+
+class _SSLSocketOverSSL:
+    # because wrap_socket() doesn't work correctly on
+    # SSLSocket, we have to do the 2nd level SSL manually
+
+    def __init__(self, ssl_sock, ctx, **kwargs):
+        self.sock = ssl_sock
+        self.incoming = ssl.MemoryBIO()
+        self.outgoing = ssl.MemoryBIO()
+        self.sslobj = ctx.wrap_bio(
+            self.incoming, self.outgoing, **kwargs)
+        self.do(self.sslobj.do_handshake)
+
+    def do(self, func, *args):
+        while True:
+            try:
+                rv = func(*args)
+                break
+            except ssl.SSLWantReadError:
+                if self.outgoing.pending:
+                    self.sock.send(self.outgoing.read())
+                self.incoming.write(self.sock.recv(65536))
+        if self.outgoing.pending:
+            self.sock.send(self.outgoing.read())
+        return rv
+
+    def send(self, data):
+        self.do(self.sslobj.write, data)
+
+    def unwrap(self):
+        self.do(self.sslobj.unwrap)
+
+    def close(self):
+        self.sock.unwrap()
+        self.sock.close()
+
+
+class _ContextBaseTests(tb.SSLTestCase):
+
+    ONLYCERT = tb._cert_fullname(__file__, 'ssl_cert.pem')
+    ONLYKEY = tb._cert_fullname(__file__, 'ssl_key.pem')
 
     def test_task_decimal_context(self):
         async def fractions(t, precision, x, y):
@@ -138,30 +263,106 @@ class _ContextBaseTests:
         del tracked
         self.assertIsNone(ref())
 
-    def test_create_server_protocol_factory_context(self):
-        cvar = contextvars.ContextVar('cvar', default='outer')
-        factory_called_future = self.loop.create_future()
-        proto = _Protocol(loop=self.loop)
-
-        def factory():
-            try:
-                self.assertEqual(cvar.get(), 'inner')
-            except Exception as e:
-                factory_called_future.set_exception(e)
+    def _run_test(self, method, **switches):
+        switches.setdefault('use_tcp', 'both')
+        use_ssl = switches.setdefault('use_ssl', 'no') in {'yes', 'both'}
+        names = ['factory']
+        options = [(_Protocol, _BufferedProtocol)]
+        for k, v in switches.items():
+            if v == 'yes':
+                options.append((True,))
+            elif v == 'no':
+                options.append((False,))
+            elif v == 'both':
+                options.append((True, False))
             else:
-                factory_called_future.set_result(None)
+                raise ValueError(f"Illegal {k}={v}, can only be yes/no/both")
+            names.append(k)
 
-            return proto
+        for combo in itertools.product(*options):
+            values = dict(zip(names, combo))
+            with self.subTest(**values):
+                cvar = contextvars.ContextVar('cvar', default='outer')
+                values['proto'] = values.pop('factory')(cvar, loop=self.loop)
 
-        async def test():
-            cvar.set('inner')
-            port = tb.find_free_port()
-            srv = await self.loop.create_server(factory, '127.0.0.1', port)
+                async def test():
+                    self.assertEqual(cvar.get(), 'outer')
+                    cvar.set('inner')
+                    tmp_dir = tempfile.TemporaryDirectory()
+                    if use_ssl:
+                        values['sslctx'] = self._create_server_ssl_context(
+                            self.ONLYCERT, self.ONLYKEY)
+                        values['client_sslctx'] = \
+                            self._create_client_ssl_context()
+                    else:
+                        values['sslctx'] = values['client_sslctx'] = None
 
-            s = socket.socket(socket.AF_INET)
+                    if values['use_tcp']:
+                        values['addr'] = ('127.0.0.1', tb.find_free_port())
+                        values['family'] = socket.AF_INET
+                    else:
+                        values['addr'] = tmp_dir.name + '/test.sock'
+                        values['family'] = socket.AF_UNIX
+
+                    try:
+                        await method(cvar=cvar, **values)
+                    finally:
+                        tmp_dir.cleanup()
+
+                self.loop.run_until_complete(test())
+
+    def _run_server_test(self, method, async_sock=False, **switches):
+        async def test(sslctx, client_sslctx, addr, family, **values):
+            if values['use_tcp']:
+                srv = await self.loop.create_server(
+                    lambda: values['proto'], *addr, ssl=sslctx)
+            else:
+                srv = await self.loop.create_unix_server(
+                    lambda: values['proto'], addr, ssl=sslctx)
+            s = socket.socket(family)
+
+            if async_sock:
+                s.setblocking(False)
+                await self.loop.sock_connect(s, addr)
+            else:
+                await self.loop.run_in_executor(
+                    None, s.connect, addr)
+                if values['use_ssl']:
+                    values['ssl_sock'] = await self.loop.run_in_executor(
+                        None, client_sslctx.wrap_socket, s)
+
+            try:
+                await method(s=s, **values)
+            finally:
+                if values['use_ssl']:
+                    values['ssl_sock'].close()
+                s.close()
+                srv.close()
+                await srv.wait_closed()
+        return self._run_test(test, **switches)
+
+    def test_create_server_protocol_factory_context(self):
+        async def test(cvar, proto, use_tcp, family, addr, **_):
+            factory_called_future = self.loop.create_future()
+
+            def factory():
+                try:
+                    self.assertEqual(cvar.get(), 'inner')
+                except Exception as e:
+                    factory_called_future.set_exception(e)
+                else:
+                    factory_called_future.set_result(None)
+
+                return proto
+
+            if use_tcp:
+                srv = await self.loop.create_server(factory, *addr)
+            else:
+                srv = await self.loop.create_unix_server(factory, addr)
+            s = socket.socket(family)
             with s:
                 s.setblocking(False)
-                await self.loop.sock_connect(s, ('127.0.0.1', port))
+                await self.loop.sock_connect(s, addr)
 
             try:
                 await factory_called_future
@@ -170,7 +371,385 @@ class _ContextBaseTests:
                 await proto.done
                 await srv.wait_closed()
 
+        self._run_test(test)
+
+    def test_create_server_connection_protocol(self):
+        async def test(proto, s, **_):
+            inner = await proto.connection_made_fut
+            self.assertEqual(inner, "inner")
+
+            await self.loop.sock_sendall(s, b'data')
+            inner = await proto.data_received_fut
+            self.assertEqual(inner, "inner")
+
+            s.shutdown(socket.SHUT_WR)
+            inner = await proto.eof_received_fut
+            self.assertEqual(inner, "inner")
+
+            s.close()
+            await proto.done
+            self.assertEqual(proto.connection_lost_ctx, "inner")
+
+        self._run_server_test(test, async_sock=True)
+
+    def test_create_ssl_server_connection_protocol(self):
+        async def test(cvar, proto, ssl_sock, **_):
+            def resume_reading(transport):
+                cvar.set("resume_reading")
+                transport.resume_reading()
+
+            try:
+                inner = await proto.connection_made_fut
+                self.assertEqual(inner, "inner")
+
+                await self.loop.run_in_executor(None, ssl_sock.send, b'data')
+                inner = await proto.data_received_fut
+                self.assertEqual(inner, "inner")
+
+                if self.implementation != 'asyncio':
+                    # this seems to be a bug in asyncio
+                    proto.data_received_fut = self.loop.create_future()
+                    proto.transport.pause_reading()
+                    await self.loop.run_in_executor(None,
+                                                    ssl_sock.send, b'data')
+                    self.loop.call_soon(resume_reading, proto.transport)
+                    inner = await proto.data_received_fut
+                    self.assertEqual(inner, "inner")
+
+                    await self.loop.run_in_executor(None, ssl_sock.unwrap)
+                else:
+                    ssl_sock.shutdown(socket.SHUT_WR)
+                inner = await proto.eof_received_fut
+                self.assertEqual(inner, "inner")
+
+                await self.loop.run_in_executor(None, ssl_sock.close)
+                await proto.done
+                self.assertEqual(proto.connection_lost_ctx, "inner")
+            finally:
+                if self.implementation == 'asyncio':
+                    # mute resource warning in asyncio
+                    proto.transport.close()
+
+        self._run_server_test(test, use_ssl='yes')
+
+    def test_create_server_manual_connection_lost(self):
+        if self.implementation == 'asyncio':
+            raise unittest.SkipTest('this seems to be a bug in asyncio')
+
+        async def test(proto, cvar, **_):
+            def close():
+                cvar.set('closing')
+                proto.transport.close()
+
+            inner = await proto.connection_made_fut
+            self.assertEqual(inner, "inner")
+
+            self.loop.call_soon(close)
+
+            await proto.done
+            self.assertEqual(proto.connection_lost_ctx, "inner")
+
+        self._run_server_test(test, async_sock=True)
+
+    def test_create_ssl_server_manual_connection_lost(self):
+        async def test(proto, cvar, ssl_sock, **_):
+            def close():
+                cvar.set('closing')
+                proto.transport.close()
+
+            inner = await proto.connection_made_fut
+            self.assertEqual(inner, "inner")
+
+            if self.implementation == 'asyncio':
+                self.loop.call_soon(close)
+            else:
+                # asyncio doesn't have the flushing phase
+
+                # put the incoming data on-hold
+                proto.transport.pause_reading()
+                # send data
+                await self.loop.run_in_executor(None,
+                                                ssl_sock.send, b'hello')
+                # schedule a proactive transport close which will trigger
+                # the flushing process to retrieve the remaining data
+                self.loop.call_soon(close)
+                # turn off the reading lock now (this also schedules a
+                # resume operation after transport.close, therefore it
+                # won't affect our test)
+                proto.transport.resume_reading()
+
+            await asyncio.sleep(0)
+            await self.loop.run_in_executor(None, ssl_sock.unwrap)
+            await proto.done
+            self.assertEqual(proto.connection_lost_ctx, "inner")
+            self.assertFalse(proto.data_received_fut.done())
+
+        self._run_server_test(test, use_ssl='yes')
+
+    def test_create_connection_protocol(self):
+        async def test(cvar, proto, addr, sslctx, client_sslctx, family,
+                       use_sock, use_ssl, use_tcp):
+            ss = socket.socket(family)
+            ss.bind(addr)
+            ss.listen(1)
+
+            def accept():
+                sock, _ = ss.accept()
+                if use_ssl:
+                    sock = sslctx.wrap_socket(sock, server_side=True)
+                return sock
+
+            async def write_over():
+                cvar.set("write_over")
+                count = 0
+                if use_ssl:
+                    proto.transport.set_write_buffer_limits(high=256, low=128)
+                    while not proto.transport.get_write_buffer_size():
+                        proto.transport.write(b'q' * 16384)
+                        count += 1
+                else:
+                    proto.transport.write(b'q' * 16384)
+                    proto.transport.set_write_buffer_limits(high=256, low=128)
+                    count += 1
+                return count
+
+            s = self.loop.run_in_executor(None, accept)
+
+            try:
+                method = ('create_connection' if use_tcp
+                          else 'create_unix_connection')
+                params = {}
+                if use_sock:
+                    cs = socket.socket(family)
+                    cs.connect(addr)
+                    params['sock'] = cs
+                    if use_ssl:
+                        params['server_hostname'] = '127.0.0.1'
+                elif use_tcp:
+                    params['host'] = addr[0]
+                    params['port'] = addr[1]
+                else:
+                    params['path'] = addr
+                    if use_ssl:
+                        params['server_hostname'] = '127.0.0.1'
+                if use_ssl:
+                    params['ssl'] = client_sslctx
+                await getattr(self.loop, method)(lambda: proto, **params)
+                s = await s
+
+                inner = await proto.connection_made_fut
+                self.assertEqual(inner, "inner")
+
+                await self.loop.run_in_executor(None, s.send, b'data')
+                inner = await proto.data_received_fut
+                self.assertEqual(inner, "inner")
+
+                if self.implementation != 'asyncio':
+                    # asyncio bug
+                    count = await self.loop.create_task(write_over())
+                    inner = await proto.pause_writing_fut
+                    self.assertEqual(inner, "inner")
+
+                    for i in range(count):
+                        await self.loop.run_in_executor(None, s.recv, 16384)
+                    inner = await proto.resume_writing_fut
+                    self.assertEqual(inner, "inner")
+
+                if use_ssl and self.implementation != 'asyncio':
+                    await self.loop.run_in_executor(None, s.unwrap)
+                else:
+                    s.shutdown(socket.SHUT_WR)
+                inner = await proto.eof_received_fut
+                self.assertEqual(inner, "inner")
+
+                s.close()
+                await proto.done
+                self.assertEqual(proto.connection_lost_ctx, "inner")
+            finally:
+                ss.close()
+                proto.transport.close()
+
+        self._run_test(test, use_sock='both', use_ssl='both')
+
+    def test_start_tls(self):
+        if self.implementation == 'asyncio':
+            raise unittest.SkipTest('this seems to be a bug in asyncio')
+
+        async def test(cvar, proto, addr, sslctx, client_sslctx, family,
+                       ssl_over_ssl, use_tcp, **_):
+            ss = socket.socket(family)
+            ss.bind(addr)
+            ss.listen(1)
+
+            def accept():
+                sock, _ = ss.accept()
+                sock = sslctx.wrap_socket(sock, server_side=True)
+                if ssl_over_ssl:
+                    sock = _SSLSocketOverSSL(sock, sslctx, server_side=True)
+                return sock
+
+            s = self.loop.run_in_executor(None, accept)
+            transport = None
+
+            try:
+                if use_tcp:
+                    await self.loop.create_connection(lambda: proto, *addr)
+                else:
+                    await self.loop.create_unix_connection(lambda: proto, addr)
+                inner = await proto.connection_made_fut
+                self.assertEqual(inner, "inner")
+
+                cvar.set('start_tls')
+                transport = await self.loop.start_tls(
+                    proto.transport, proto, client_sslctx,
+                    server_hostname='127.0.0.1',
+                )
+
+                if ssl_over_ssl:
+                    cvar.set('start_tls_over_tls')
+                    transport = await self.loop.start_tls(
+                        transport, proto, client_sslctx,
+                        server_hostname='127.0.0.1',
+                    )
+
+                s = await s
+
+                await self.loop.run_in_executor(None, s.send, b'data')
+                inner = await proto.data_received_fut
+                self.assertEqual(inner, "inner")
+
+                await self.loop.run_in_executor(None, s.unwrap)
+                inner = await proto.eof_received_fut
+                self.assertEqual(inner, "inner")
+
+                s.close()
+                await proto.done
+                self.assertEqual(proto.connection_lost_ctx, "inner")
+            finally:
+                ss.close()
+                if transport:
+                    transport.close()
+
+        self._run_test(test, use_ssl='yes', ssl_over_ssl='both')
+
+    def test_connect_accepted_socket(self):
+        async def test(proto, addr, family, sslctx, client_sslctx,
+                       use_ssl, **_):
+            ss = socket.socket(family)
+            ss.bind(addr)
+            ss.listen(1)
+            s = self.loop.run_in_executor(None, ss.accept)
+            cs = socket.socket(family)
+            cs.connect(addr)
+            s, _ = await s
+
+            try:
+                if use_ssl:
+                    cs = self.loop.run_in_executor(
+                        None, client_sslctx.wrap_socket, cs)
+                    await self.loop.connect_accepted_socket(lambda: proto, s,
+                                                            ssl=sslctx)
+                    cs = await cs
+                else:
+                    await self.loop.connect_accepted_socket(lambda: proto, s)
+
+                inner = await proto.connection_made_fut
+                self.assertEqual(inner, "inner")
+
+                await self.loop.run_in_executor(None, cs.send, b'data')
+                inner = await proto.data_received_fut
+                self.assertEqual(inner, "inner")
+
+                if use_ssl and self.implementation != 'asyncio':
+                    await self.loop.run_in_executor(None, cs.unwrap)
+                else:
+                    cs.shutdown(socket.SHUT_WR)
+                inner = await proto.eof_received_fut
+                self.assertEqual(inner, "inner")
+
+                cs.close()
+                await proto.done
+                self.assertEqual(proto.connection_lost_ctx, "inner")
+            finally:
+                proto.transport.close()
+                ss.close()
+
+        self._run_test(test, use_ssl='both')
+
+    def test_subprocess_protocol(self):
+        cvar = contextvars.ContextVar('cvar', default='outer')
+        proto = _SubprocessProtocol(cvar, loop=self.loop)
+
+        async def test():
+            self.assertEqual(cvar.get(), 'outer')
+            cvar.set('inner')
+            await self.loop.subprocess_exec(lambda: proto,
+                                            *_AsyncioTests.PROGRAM_CAT)
+
+            try:
+                inner = await proto.connection_made_fut
+                self.assertEqual(inner, "inner")
+
+                proto.transport.get_pipe_transport(0).write(b'data')
+                proto.transport.get_pipe_transport(0).write_eof()
+                inner = await proto.data_received_fut
+                self.assertEqual(inner, "inner")
+
+                inner = await proto.pipe_connection_lost_fut
+                self.assertEqual(inner, "inner")
+
+                inner = await proto.process_exited_fut
+                if self.implementation != 'asyncio':
+                    # bug in asyncio
+                    self.assertEqual(inner, "inner")
+
+                await proto.done
+                if self.implementation != 'asyncio':
+                    # bug in asyncio
+                    self.assertEqual(proto.connection_lost_ctx, "inner")
+            finally:
+                proto.transport.close()
+
         self.loop.run_until_complete(test())
+
+    def test_datagram_protocol(self):
+        cvar = contextvars.ContextVar('cvar', default='outer')
+        proto = _DatagramProtocol(cvar, loop=self.loop)
+        server_addr = ('127.0.0.1', 8888)
+        client_addr = ('127.0.0.1', 0)
+
+        async def run():
+            self.assertEqual(cvar.get(), 'outer')
+            cvar.set('inner')
+
+            def close():
+                cvar.set('closing')
+                proto.transport.close()
+
+            try:
+                await self.loop.create_datagram_endpoint(
+                    lambda: proto, local_addr=server_addr)
+                inner = await proto.connection_made_fut
+                self.assertEqual(inner, "inner")
+
+                s = socket.socket(socket.AF_INET, type=socket.SOCK_DGRAM)
+                s.bind(client_addr)
+                s.sendto(b'data', server_addr)
+                inner = await proto.data_received_fut
+                self.assertEqual(inner, "inner")
+
+                self.loop.call_soon(close)
+                await proto.done
+                if self.implementation != 'asyncio':
+                    # bug in asyncio
+                    self.assertEqual(proto.connection_lost_ctx, "inner")
+            finally:
+                proto.transport.close()
+                s.close()
+                # let transports close
+                await asyncio.sleep(0.1)
+
+        self.loop.run_until_complete(run())
 
 
 class Test_UV_Context(_ContextBaseTests, tb.UVTestCase):

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -190,11 +190,10 @@ class _TestSockets:
             self.loop.run_until_complete(asyncio.sleep(0.01))
 
     def test_sock_cancel_add_reader_race(self):
-        if self.is_asyncio_loop():
-            if sys.version_info[:2] == (3, 8):
-                # asyncio 3.8.x has a regression; fixed in 3.9.0
-                # tracked in https://bugs.python.org/issue30064
-                raise unittest.SkipTest()
+        if self.is_asyncio_loop() and sys.version_info[:2] == (3, 8):
+            # asyncio 3.8.x has a regression; fixed in 3.9.0
+            # tracked in https://bugs.python.org/issue30064
+            raise unittest.SkipTest()
 
         srv_sock_conn = None
 
@@ -247,8 +246,8 @@ class _TestSockets:
         self.loop.run_until_complete(server())
 
     def test_sock_send_before_cancel(self):
-        if self.is_asyncio_loop() and sys.version_info[:3] == (3, 8, 0):
-            # asyncio 3.8.0 seems to have a regression;
+        if self.is_asyncio_loop() and sys.version_info[:2] == (3, 8):
+            # asyncio 3.8.x has a regression; fixed in 3.9.0
             # tracked in https://bugs.python.org/issue30064
             raise unittest.SkipTest()
 

--- a/uvloop/cbhandles.pyx
+++ b/uvloop/cbhandles.pyx
@@ -333,71 +333,72 @@ cdef new_Handle(Loop loop, object callback, object args, object context):
     return handle
 
 
-cdef new_MethodHandle(Loop loop, str name, method_t callback, object ctx):
+cdef new_MethodHandle(Loop loop, str name, method_t callback, object context,
+                      object bound_to):
     cdef Handle handle
     handle = Handle.__new__(Handle)
     handle._set_loop(loop)
-    handle._set_context(None)
+    handle._set_context(context)
 
     handle.cb_type = 2
     handle.meth_name = name
 
     handle.callback = <void*> callback
-    handle.arg1 = ctx
+    handle.arg1 = bound_to
 
     return handle
 
 
-cdef new_MethodHandle1(Loop loop, str name, method1_t callback,
-                       object ctx, object arg):
+cdef new_MethodHandle1(Loop loop, str name, method1_t callback, object context,
+                       object bound_to, object arg):
 
     cdef Handle handle
     handle = Handle.__new__(Handle)
     handle._set_loop(loop)
-    handle._set_context(None)
+    handle._set_context(context)
 
     handle.cb_type = 3
     handle.meth_name = name
 
     handle.callback = <void*> callback
-    handle.arg1 = ctx
+    handle.arg1 = bound_to
     handle.arg2 = arg
 
     return handle
 
 
-cdef new_MethodHandle2(Loop loop, str name, method2_t callback, object ctx,
-                       object arg1, object arg2):
+cdef new_MethodHandle2(Loop loop, str name, method2_t callback, object context,
+                       object bound_to, object arg1, object arg2):
 
     cdef Handle handle
     handle = Handle.__new__(Handle)
     handle._set_loop(loop)
-    handle._set_context(None)
+    handle._set_context(context)
 
     handle.cb_type = 4
     handle.meth_name = name
 
     handle.callback = <void*> callback
-    handle.arg1 = ctx
+    handle.arg1 = bound_to
     handle.arg2 = arg1
     handle.arg3 = arg2
 
     return handle
 
 
-cdef new_MethodHandle3(Loop loop, str name, method3_t callback, object ctx,
-                       object arg1, object arg2, object arg3):
+cdef new_MethodHandle3(Loop loop, str name, method3_t callback, object context,
+                       object bound_to, object arg1, object arg2, object arg3):
 
     cdef Handle handle
     handle = Handle.__new__(Handle)
     handle._set_loop(loop)
-    handle._set_context(None)
+    handle._set_context(context)
 
     handle.cb_type = 5
     handle.meth_name = name
 
     handle.callback = <void*> callback
-    handle.arg1 = ctx
+    handle.arg1 = bound_to
     handle.arg2 = arg1
     handle.arg3 = arg2
     handle.arg4 = arg3

--- a/uvloop/handles/basetransport.pyx
+++ b/uvloop/handles/basetransport.pyx
@@ -26,6 +26,7 @@ cdef class UVBaseTransport(UVSocketHandle):
             new_MethodHandle(self._loop,
                              "UVTransport._call_connection_made",
                              <method_t>self._call_connection_made,
+                             self.context,
                              self))
 
     cdef inline _schedule_call_connection_lost(self, exc):
@@ -33,6 +34,7 @@ cdef class UVBaseTransport(UVSocketHandle):
             new_MethodHandle1(self._loop,
                               "UVTransport._call_connection_lost",
                               <method1_t>self._call_connection_lost,
+                              self.context,
                               self, exc))
 
     cdef _fatal_error(self, exc, throw, reason=None):
@@ -66,7 +68,9 @@ cdef class UVBaseTransport(UVSocketHandle):
         if not self._protocol_paused:
             self._protocol_paused = 1
             try:
-                self._protocol.pause_writing()
+                # _maybe_pause_protocol() is always triggered from user-calls,
+                # so we must copy the context to avoid entering context twice
+                self.context.copy().run(self._protocol.pause_writing)
             except (KeyboardInterrupt, SystemExit):
                 raise
             except BaseException as exc:
@@ -84,7 +88,10 @@ cdef class UVBaseTransport(UVSocketHandle):
         if self._protocol_paused and size <= self._low_water:
             self._protocol_paused = 0
             try:
-                self._protocol.resume_writing()
+                # We're copying the context to avoid entering context twice,
+                # even though it's not always necessary to copy - it's easier
+                # to copy here than passing down a copied context.
+                self.context.copy().run(self._protocol.resume_writing)
             except (KeyboardInterrupt, SystemExit):
                 raise
             except BaseException as exc:

--- a/uvloop/handles/handle.pxd
+++ b/uvloop/handles/handle.pxd
@@ -5,6 +5,7 @@ cdef class UVHandle:
         readonly _source_traceback
         bint _closed
         bint _inited
+        object context
 
         # Added to enable current UDPTransport implementation,
         # which doesn't use libuv handles.

--- a/uvloop/handles/pipe.pxd
+++ b/uvloop/handles/pipe.pxd
@@ -14,7 +14,7 @@ cdef class UnixTransport(UVStream):
 
     @staticmethod
     cdef UnixTransport new(Loop loop, object protocol, Server server,
-                           object waiter)
+                           object waiter, object context)
 
     cdef connect(self, char* addr)
 

--- a/uvloop/handles/stream.pxd
+++ b/uvloop/handles/stream.pxd
@@ -19,7 +19,7 @@ cdef class UVStream(UVBaseTransport):
     # All "inline" methods are final
 
     cdef inline _init(self, Loop loop, object protocol, Server server,
-                      object waiter)
+                      object waiter, object context)
 
     cdef inline _exec_write(self)
 

--- a/uvloop/handles/stream.pyx
+++ b/uvloop/handles/stream.pyx
@@ -612,7 +612,7 @@ cdef class UVStream(UVBaseTransport):
         except AttributeError:
             keep_open = False
         else:
-            keep_open = meth()
+            keep_open = self.context.run(meth)
 
         if keep_open:
             # We're keeping the connection open so the
@@ -631,8 +631,8 @@ cdef class UVStream(UVBaseTransport):
                 self._shutdown()
 
     cdef inline _init(self, Loop loop, object protocol, Server server,
-                      object waiter):
-
+                      object waiter, object context):
+        self.context = context
         self._set_protocol(protocol)
         self._start_init(loop)
 
@@ -826,7 +826,7 @@ cdef inline void __uv_stream_on_read_impl(uv.uv_stream_t* stream,
         if UVLOOP_DEBUG:
             loop._debug_stream_read_cb_total += 1
 
-        sc._protocol_data_received(loop._recv_buffer[:nread])
+        sc.context.run(sc._protocol_data_received, loop._recv_buffer[:nread])
     except BaseException as exc:
         if UVLOOP_DEBUG:
             loop._debug_stream_read_cb_errors_total += 1
@@ -911,7 +911,7 @@ cdef void __uv_stream_buffered_alloc(uv.uv_handle_t* stream,
 
     sc._read_pybuf_acquired = 0
     try:
-        buf = sc._protocol_get_buffer(suggested_size)
+        buf = sc.context.run(sc._protocol_get_buffer, suggested_size)
         PyObject_GetBuffer(buf, pybuf, PyBUF_WRITABLE)
         got_buf = 1
     except BaseException as exc:
@@ -976,7 +976,7 @@ cdef void __uv_stream_buffered_on_read(uv.uv_stream_t* stream,
         if UVLOOP_DEBUG:
             loop._debug_stream_read_cb_total += 1
 
-        sc._protocol_buffer_updated(nread)
+        sc.context.run(sc._protocol_buffer_updated, nread)
     except BaseException as exc:
         if UVLOOP_DEBUG:
             loop._debug_stream_read_cb_errors_total += 1

--- a/uvloop/handles/streamserver.pxd
+++ b/uvloop/handles/streamserver.pxd
@@ -7,7 +7,6 @@ cdef class UVStreamServer(UVSocketHandle):
         object protocol_factory
         bint opened
         Server _server
-        object listen_context
 
     # All "inline" methods are final
 
@@ -23,4 +22,5 @@ cdef class UVStreamServer(UVSocketHandle):
     cdef inline listen(self)
     cdef inline _on_listen(self)
 
-    cdef UVStream _make_new_transport(self, object protocol, object waiter)
+    cdef UVStream _make_new_transport(self, object protocol, object waiter,
+                                      object context)

--- a/uvloop/handles/streamserver.pxd
+++ b/uvloop/handles/streamserver.pxd
@@ -7,6 +7,7 @@ cdef class UVStreamServer(UVSocketHandle):
         object protocol_factory
         bint opened
         Server _server
+        object listen_context
 
     # All "inline" methods are final
 

--- a/uvloop/handles/tcp.pxd
+++ b/uvloop/handles/tcp.pxd
@@ -23,4 +23,4 @@ cdef class TCPTransport(UVStream):
 
     @staticmethod
     cdef TCPTransport new(Loop loop, object protocol, Server server,
-                          object waiter)
+                          object waiter, object context)

--- a/uvloop/handles/tcp.pyx
+++ b/uvloop/handles/tcp.pyx
@@ -91,9 +91,11 @@ cdef class TCPServer(UVStreamServer):
         else:
             self._mark_as_open()
 
-    cdef UVStream _make_new_transport(self, object protocol, object waiter):
+    cdef UVStream _make_new_transport(self, object protocol, object waiter,
+                                      object context):
         cdef TCPTransport tr
-        tr = TCPTransport.new(self._loop, protocol, self._server, waiter)
+        tr = TCPTransport.new(self._loop, protocol, self._server, waiter,
+                              context)
         return <UVStream>tr
 
 
@@ -102,11 +104,11 @@ cdef class TCPTransport(UVStream):
 
     @staticmethod
     cdef TCPTransport new(Loop loop, object protocol, Server server,
-                          object waiter):
+                          object waiter, object context):
 
         cdef TCPTransport handle
         handle = TCPTransport.__new__(TCPTransport)
-        handle._init(loop, protocol, server, waiter)
+        handle._init(loop, protocol, server, waiter, context)
         __tcp_init_uv_handle(<UVStream>handle, loop, uv.AF_UNSPEC)
         handle.__peername_set = 0
         handle.__sockname_set = 0

--- a/uvloop/handles/udp.pxd
+++ b/uvloop/handles/udp.pxd
@@ -19,4 +19,4 @@ cdef class UDPTransport(UVBaseTransport):
     cdef _send(self, object data, object addr)
 
     cdef _on_receive(self, bytes data, object exc, object addr)
-    cdef _on_sent(self, object exc)
+    cdef _on_sent(self, object exc, object context=*)

--- a/uvloop/sslproto.pxd
+++ b/uvloop/sslproto.pxd
@@ -27,6 +27,7 @@ cdef class _SSLProtocolTransport:
         Loop _loop
         SSLProtocol _ssl_protocol
         bint _closed
+        object context
 
 
 cdef class SSLProtocol:
@@ -97,17 +98,17 @@ cdef class SSLProtocol:
 
     # Shutdown flow
 
-    cdef _start_shutdown(self)
+    cdef _start_shutdown(self, object context=*)
     cdef _check_shutdown_timeout(self)
-    cdef _do_read_into_void(self)
-    cdef _do_flush(self)
-    cdef _do_shutdown(self)
+    cdef _do_read_into_void(self, object context)
+    cdef _do_flush(self, object context=*)
+    cdef _do_shutdown(self, object context=*)
     cdef _on_shutdown_complete(self, shutdown_exc)
     cdef _abort(self, exc)
 
     # Outgoing flow
 
-    cdef _write_appdata(self, list_of_data)
+    cdef _write_appdata(self, list_of_data, object context)
     cdef _do_write(self)
     cdef _process_outgoing(self)
 
@@ -116,18 +117,18 @@ cdef class SSLProtocol:
     cdef _do_read(self)
     cdef _do_read__buffered(self)
     cdef _do_read__copied(self)
-    cdef _call_eof_received(self)
+    cdef _call_eof_received(self, object context=*)
 
     # Flow control for writes from APP socket
 
-    cdef _control_app_writing(self)
+    cdef _control_app_writing(self, object context=*)
     cdef size_t _get_write_buffer_size(self)
     cdef _set_write_buffer_limits(self, high=*, low=*)
 
     # Flow control for reads to APP socket
 
     cdef _pause_reading(self)
-    cdef _resume_reading(self)
+    cdef _resume_reading(self, object context)
 
     # Flow control for reads from SSL socket
 


### PR DESCRIPTION
A quick recap of uvloop core:

![uvloop handles (4)](https://user-images.githubusercontent.com/1751601/105397934-506fa880-5be7-11eb-8756-de24c0bf22b6.png)

1. `Loop` is the uvloop-version of an asyncio event loop, exposing APIs to create `UVHandle`s like TCP transports.
2. `UVHandle` is the base class of uvloop wrappers of the libuv `uv_handle_t` structs, see the full family below.
3. Each `UVHandle` references ~one~ zero or more `Handle` instances that encapsulate the actual callback, its arguments, and a PEP-567 context.
4. There's at least one `cdef` function per `UVHandle` that is registered to the libuv `uv_handle_t` struct. This function usually just triggers running the `Handle`.
5. [UPDATE] Not all `UVHandle` uses `Handle` for callbacks, and we don't want to change that.

```
UVHandle                                       (handle)
    +- UVAsync                                 (async_)
    +- UVCheck                                 (check)
    +- UVIdle                                  (idle)
    +- UVPoll                                  (poll)
    +- UVProcess                               (process)
    |      +- UVProcessTransport               (process)
    +- UVSocketHandle                          (handle)
    |      +- UVBaseTransport                  (basetransport)
    |      |      +- UDPTransport              (udp)
    |      |      +- UVStream                  (stream)
    |      |             +- TCPTransport       (tcp)
    |      |             +- UnixTransport      (pipe)
    |      |             +- ReadUnixTransport  (pipe)
    |      |             +- WriteUnixTransport (pipe)
    |      +- UVStreamServer                   (streamserver)
    |             +- TCPServer                 (tcp)
    |             +- UnixServer                (pipe)
    +- UVTimer                                 (timer)
```

~What is missing is e.g. the `listen_handle` of some `UVHandle` subclasses like the `UVStreamServer`. For now, it calls the actual callback (`_on_listen`) directly without PEP-567 context. So this PR should add those missing `Handle`s.~

~The tricky part is, the current `Handle` supports only fixed parameters provided at initialization, what is needed for callbacks like `_on_listen` or `__uv_stream_on_read` is a partial-like `Handle._run_with_param()`.~

List of `UVHandle`s to check:

- [x] `UVAsync`
- [x] `UVCheck`
- [x] `UVIdle`
- [x] `UVPoll`
- [x] `UVProcess`
- [x] `UVProcessTransport`
- [x] `UDPTransport`
- [x] `UVStream`
- [x] `UVStreamServer`
- [x] `UVTimer`

## Principals

1. Each `UVHandle` instance (including transports, servers, etc) sticks to one context where it was created from and/or started to take effect.
2. All user code triggered by `UVHandle` (mostly protocol callbacks, but also protocol factory) runs in the same context.
3. Affiliated `UVHandle` instances share the same context - for example, protocol callbacks are always called in the same context even though the transport is upgraded by `start_tls()` in a different context (even multiple times, a.k.a. SSL over SSL).
4. By "the same context", it's not necessarily the same `Context` instance - it can be a copied instance. Therefore, changes to a `ContextVar` are not always carried between different protocol callbacks. But all callbacks could see the same inherited value from the context where the `UVHandle` was created or started.
5. When in need, we lean towards using `Context.copy()` or `copy_context()` in user-triggered events, and reuse existing `Context` instances for uvloop-triggered events, so as to avoid re-entering the same context twice.
6. The above `copy_context()` is only applied to direct method calls, callbacks through e.g. `loop.call_soon()` are not considered necessary to copy the context.
7. Don't over-optimize. The context copy operation is actually fast (underlying context data is not copied because of the [copy-on-write design](https://www.python.org/dev/peps/pep-0567/#id22)), it is okay to copy when unnecessary if it means to avoid complication.

### Example 1: Client Protocol

```python
import asyncio
from contextvars import ContextVar

import uvloop

uvloop.install()
cvar = ContextVar("cvar", default="in initial context")


class Protocol(asyncio.Protocol):
    def __init__(self):
        self.pipe = asyncio.Queue()

    def connection_made(self, transport):
        self.pipe.put_nowait("connection_made() " + cvar.get())

    def data_received(self, data):
        self.pipe.put_nowait("data_received() " + cvar.get())

    def connection_lost(self, exc):
        self.pipe.put_nowait("connection_lost() " + cvar.get())


async def main():
    cvar.set("in context of create_connection()")
    trans, proto = await asyncio.get_event_loop().create_connection(
        Protocol, "google.com", 80
    )
    print(await proto.pipe.get())

    cvar.set("in context of write()")
    trans.write(b"GET / HTTP.1.1\r\nHost: google.com\r\n\r\n")
    print(await proto.pipe.get())

    cvar.set("in context of close()")
    trans.close()
    print(await proto.pipe.get())


asyncio.run(main())
```

Expected result:

```
connection_made() in context of create_connection()
data_received() in context of create_connection()
connection_lost() in context of create_connection()
```

### Example 2: Server Protocol

```python
import asyncio
import socket
from contextvars import ContextVar

import uvloop

uvloop.install()
cvar = ContextVar("cvar", default="in initial context")


class Protocol(asyncio.Protocol):
    def __init__(self, pipe):
        self.pipe = pipe
        self.pipe.put_nowait("Protocol() " + cvar.get())

    def connection_made(self, transport):
        self.pipe.put_nowait("connection_made() " + cvar.get())

    def data_received(self, data):
        self.pipe.put_nowait("data_received() " + cvar.get())

    def connection_lost(self, exc):
        self.pipe.put_nowait("connection_lost() " + cvar.get())


async def main():
    loop = asyncio.get_event_loop()
    run = lambda *args: loop.run_in_executor(None, *args)
    pipe = asyncio.Queue()

    cvar.set("in context of create_server()")
    server = await loop.create_server(
        lambda: Protocol(pipe), "127.0.0.1", 0
    )

    s = socket.socket()
    await run(s.connect, server.sockets[0].getsockname())
    print(await pipe.get())
    print(await pipe.get())

    await run(s.send, b'data')
    print(await pipe.get())

    await run(s.close)
    print(await pipe.get())


asyncio.run(main())
```

Expected result:

```
Protocol() in context of create_server()
connection_made() in context of create_server()
data_received() in context of create_server()
connection_lost() in context of create_server()
```

### Example 3: `start_serving`

Similar to example 2, but start serving in a different context:

```python
async def main():
    ...

    cvar.set("in context of create_server()")
    server = await loop.create_server(
        lambda: Protocol(pipe), "127.0.0.1", 0, start_serving=False,
    )
    
    cvar.set("in context of start_serving()")
    await server.start_serving()

    ...
```

Expected result:

```
Protocol() in context of start_serving()
connection_made() in context of start_serving()
data_received() in context of start_serving()
connection_lost() in context of start_serving()
```

### Example 4: TLS Upgrade

```python
import asyncio
import socket
import ssl
from contextvars import ContextVar

import uvloop

uvloop.install()
cvar = ContextVar("cvar", default="in initial context")


class Protocol(asyncio.Protocol):
    def __init__(self, pipe):
        self.pipe = pipe
        self.pipe.put_nowait("Protocol() " + cvar.get())

    def connection_made(self, transport):
        self.pipe.put_nowait((transport, self))
        self.pipe.put_nowait("connection_made() " + cvar.get())

    def data_received(self, data):
        self.pipe.put_nowait("data_received() " + cvar.get())

    def connection_lost(self, exc):
        self.pipe.put_nowait("connection_lost() " + cvar.get())


async def main():
    loop = asyncio.get_event_loop()
    run = lambda *args: loop.run_in_executor(None, *args)
    pipe = asyncio.Queue()

    cvar.set("in context of create_server()")
    server = await loop.create_server(
        lambda: Protocol(pipe),
        "127.0.0.1",
        0,
        start_serving=False,
    )

    cvar.set("in context of start_serving()")
    await server.start_serving()

    s = socket.socket()
    await run(s.connect, server.sockets[0].getsockname())
    print(await pipe.get())
    trans, proto = await pipe.get()
    print(await pipe.get())

    await run(s.send, b"data")
    print(await pipe.get())

    sslctx = ssl.SSLContext()
    sslctx.load_cert_chain("tests/certs/ssl_cert.pem", "tests/certs/ssl_key.pem")
    client_sslctx = ssl.create_default_context()
    client_sslctx.check_hostname = False
    client_sslctx.verify_mode = ssl.CERT_NONE
    s = run(client_sslctx.wrap_socket, s)

    cvar.set("in context of start_tls()")
    await loop.start_tls(trans, proto, sslctx, server_side=True)
    s = await s
    await run(s.send, b"data")
    print(await pipe.get())

    await run(s.close)
    print(await pipe.get())


asyncio.run(main())
```

Expected result:

```
Protocol() in context of start_serving()
connection_made() in context of start_serving()
data_received() in context of start_serving()
data_received() in context of start_serving()
connection_lost() in context of start_serving()
```