### PR TITLE
Implement loop.shutdown_default_executor()

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -689,6 +689,17 @@ class _TestBase:
             asyncio.wait_for(foo(), timeout=float('inf')))
         self.assertEqual(res, 123)
 
+    def test_shutdown_default_executor(self):
+        if not hasattr(self.loop, "shutdown_default_executor"):
+            raise unittest.SkipTest()
+
+        async def foo():
+            await self.loop.run_in_executor(None, time.sleep, .1)
+
+        self.loop.run_until_complete(foo())
+        self.loop.run_until_complete(
+            self.loop.shutdown_default_executor())
+
 
 class TestBaseUV(_TestBase, UVTestCase):
 

--- a/uvloop/includes/stdlib.pxi
+++ b/uvloop/includes/stdlib.pxi
@@ -134,6 +134,7 @@ cdef int ssl_SSL_ERROR_WANT_WRITE = ssl.SSL_ERROR_WANT_WRITE
 cdef int ssl_SSL_ERROR_SYSCALL = ssl.SSL_ERROR_SYSCALL
 
 cdef uint64_t MAIN_THREAD_ID = <uint64_t><int64_t>threading.main_thread().ident
+cdef threading_Thread = threading.Thread
 
 cdef int subprocess_PIPE = subprocess.PIPE
 cdef int subprocess_STDOUT = subprocess.STDOUT

--- a/uvloop/loop.pxd
+++ b/uvloop/loop.pxd
@@ -83,6 +83,8 @@ cdef class Loop:
         object _asyncgens
         bint _asyncgens_shutdown_called
 
+        bint _executor_shutdown_called
+
         char _recv_buffer[UV_STREAM_RECV_BUF_SIZE]
         bint _recv_buffer_in_use
 


### PR DESCRIPTION
Closes #349.

Since I don't have too much experience with Cython, I wasn't entirely certain about the purpose of `uvloop/includes/stdlib.pxi`, but I assumed that `threading.Thread` should be included there since it was also done for `concurrent.futures.ThreadPoolExecutor`. At a glance, it seems to be a means of importing the classes from stdlib modules at compile time rather than at run time? I'd appreciate clarification on this if anyone has the time to explain.

Otherwise, it's mostly similar to the reference implementation in [asyncio](https://github.com/python/cpython/pull/15735/files).