### PR TITLE
Add typings

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,8 @@
 [flake8]
-filename = *.py,*.pyx,*.pxd,*.pxi
+filename = *.py,*.pyx,*.pxd,*.pxi,*.pyi
 ignore = E402,E731,D100,D101,D102,D103,D104,D105,W503,W504,E252
 exclude = .git,__pycache__,build,dist,.eggs,postgres,vendor
 
-per-file-ignores = *.pyx,*.pxd,*.pxi: E211, E222, E225, E226, E227, E999
+per-file-ignores =
+    *.pyx,*.pxd,*.pxi: E211, E222, E225, E226, E227, E999
+    *.pyi: F401, F403, F405, F811, E127, E128, E203, E266, E301, E302, E305, E501, E701, E704, E741, B303, W503, W504

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ uvloop/loop.*.pyd
 /.mypy_cache/
 /.vscode
 /.eggs
+/.venv*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,9 @@
 recursive-include docs *.py *.rst
 recursive-include examples *.py
 recursive-include tests *.py *.pem
-recursive-include uvloop *.pyx *.pxd *.pxi *.py *.c *.h
+recursive-include uvloop *.pyx *.pxd *.pxi *.py *.c *.h *.pyi py.typed
 recursive-include vendor/libuv *
 recursive-exclude vendor/libuv/.git *
 recursive-exclude vendor/libuv/docs *
 recursive-exclude vendor/libuv/img *
-include LICENSE-MIT LICENSE-APACHE README.rst Makefile performance.png .flake8
+include LICENSE-MIT LICENSE-APACHE README.rst Makefile performance.png .flake8 mypy.ini

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,11 @@
+[mypy]
+incremental = True
+strict = True
+implicit_reexport = True
+# disallow_any_unimported = True
+
+[mypy-uvloop._patch]
+ignore_errors = True
+
+[mypy-uvloop._testbase]
+ignore_errors = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,11 +1,6 @@
 [mypy]
 incremental = True
 strict = True
-implicit_reexport = True
-# disallow_any_unimported = True
-
-[mypy-uvloop._patch]
-ignore_errors = True
 
 [mypy-uvloop._testbase]
 ignore_errors = True

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ TEST_DEPENDENCIES = [
     'flake8~=3.7.9',
     'psutil',
     'pycodestyle~=2.5.0',
-    'pyOpenSSL~=19.0.0'
+    'pyOpenSSL~=19.0.0',
+    'mypy~=0.800',
 ]
 
 # Dependencies required to build documentation.

--- a/setup.py
+++ b/setup.py
@@ -29,9 +29,9 @@ TEST_DEPENDENCIES = [
     # their combination breaks too often
     # (example breakage: https://gitlab.com/pycqa/flake8/issues/427)
     'aiohttp',
-    'flake8~=3.7.9',
+    'flake8~=3.8.4',
     'psutil',
-    'pycodestyle~=2.5.0',
+    'pycodestyle~=2.6.0',
     'pyOpenSSL~=19.0.0',
     'mypy~=0.800',
 ]

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ TEST_DEPENDENCIES = [
     'psutil',
     'pycodestyle~=2.6.0',
     'pyOpenSSL~=19.0.0',
-    'mypy~=0.800',
+    'mypy>=0.800',
 ]
 
 # Dependencies required to build documentation.

--- a/tests/test_sourcecode.py
+++ b/tests/test_sourcecode.py
@@ -33,3 +33,34 @@ class TestFlake8(unittest.TestCase):
                 output = ex.output.decode()
                 raise AssertionError(
                     'flake8 validation failed:\n{}'.format(output)) from None
+
+    def test_mypy(self):
+        edgepath = find_uvloop_root()
+        config_path = os.path.join(edgepath, 'mypy.ini')
+        if not os.path.exists(config_path):
+            raise RuntimeError('could not locate mypy.ini file')
+
+        try:
+            import mypy  # NoQA
+        except ImportError:
+            raise unittest.SkipTest('mypy moudule is missing')
+
+        try:
+            subprocess.run(
+                [
+                    sys.executable,
+                    '-m',
+                    'mypy',
+                    '--config-file',
+                    config_path,
+                    'uvloop'
+                ],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                cwd=edgepath
+            )
+        except subprocess.CalledProcessError as ex:
+            output = ex.output.decode()
+            raise AssertionError(
+                'mypy validation failed:\n{}'.format(output)) from None

--- a/tests/test_sourcecode.py
+++ b/tests/test_sourcecode.py
@@ -8,7 +8,7 @@ def find_uvloop_root():
     return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
-class TestFlake8(unittest.TestCase):
+class TestSourceCode(unittest.TestCase):
 
     def test_flake8(self):
         edgepath = find_uvloop_root()

--- a/uvloop/__init__.py
+++ b/uvloop/__init__.py
@@ -1,4 +1,5 @@
 import asyncio as __asyncio
+import typing as _typing
 
 from asyncio.events import BaseDefaultEventLoopPolicy as __BasePolicy
 
@@ -10,16 +11,16 @@ from ._version import __version__  # NOQA
 __all__ = ('new_event_loop', 'install', 'EventLoopPolicy')
 
 
-class Loop(__BaseLoop, __asyncio.AbstractEventLoop):
+class Loop(__BaseLoop, __asyncio.AbstractEventLoop):  # type: ignore[misc]
     pass
 
 
-def new_event_loop():
+def new_event_loop() -> Loop:
     """Return a new event loop."""
     return Loop()
 
 
-def install():
+def install() -> None:
     """A helper function to install uvloop policy."""
     __asyncio.set_event_loop_policy(EventLoopPolicy())
 
@@ -36,5 +37,18 @@ class EventLoopPolicy(__BasePolicy):
     <uvloop.Loop running=False closed=False debug=False>
     """
 
-    def _loop_factory(self):
+    def _loop_factory(self) -> Loop:
         return new_event_loop()
+
+    if _typing.TYPE_CHECKING:
+        # EventLoopPolicy doesn't implement these, but since they are marked
+        # as abstract in typeshed, we have to put them in so mypy thinks
+        # the base methods are overridden. This is the same approach taken
+        # for the Windows event loop policy classes in typeshed.
+        def get_child_watcher(self) -> _typing.NoReturn:
+            ...
+
+        def set_child_watcher(
+            self, watcher: _typing.Any
+        ) -> _typing.NoReturn:
+            ...

--- a/uvloop/_noop.py
+++ b/uvloop/_noop.py
@@ -1,3 +1,3 @@
-def noop():
+def noop() -> None:
     """Empty function to invoke CPython ceval loop."""
     return

--- a/uvloop/loop.pyi
+++ b/uvloop/loop.pyi
@@ -1,6 +1,5 @@
 import asyncio
 import ssl
-import sys
 from socket import AddressFamily, SocketKind, _Address, _RetAddress, socket
 from typing import (
     IO,

--- a/uvloop/loop.pyi
+++ b/uvloop/loop.pyi
@@ -1,0 +1,290 @@
+import asyncio
+import ssl
+import sys
+from socket import AddressFamily, SocketKind, _Address, _RetAddress, socket
+from typing import (
+    IO,
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    Generator,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Union,
+    overload,
+)
+
+_T = TypeVar('_T')
+_Context = Dict[str, Any]
+_ExceptionHandler = Callable[[asyncio.AbstractEventLoop, _Context], Any]
+_SSLContext = Union[bool, None, ssl.SSLContext]
+
+class Loop:
+    def call_soon(
+        self, callback: Callable[..., Any], *args: Any, context: Optional[Any] = ...
+    ) -> asyncio.Handle: ...
+    def call_soon_threadsafe(
+        self, callback: Callable[..., Any], *args: Any, context: Optional[Any] = ...
+    ) -> asyncio.Handle: ...
+    def call_later(
+        self, delay: float, callback: Callable[..., Any], *args: Any, context: Optional[Any] = ...
+    ) -> asyncio.TimerHandle: ...
+    def call_at(
+        self, when: float, callback: Callable[..., Any], *args: Any, context: Optional[Any] = ...
+    ) -> asyncio.TimerHandle: ...
+    def time(self) -> float: ...
+    def stop(self) -> None: ...
+    def run_forever(self) -> None: ...
+    def close(self) -> None: ...
+    def get_debug(self) -> bool: ...
+    def set_debug(self, enabled: bool) -> None: ...
+    def is_running(self) -> bool: ...
+    def is_closed(self) -> bool: ...
+    def create_future(self) -> asyncio.Future[Any]: ...
+    def create_task(
+        self,
+        coro: Union[Awaitable[_T], Generator[Any, None, _T]],
+        *,
+        name: Optional[str] = ...,
+    ) -> asyncio.Task[_T]: ...
+    def set_task_factory(
+        self,
+        factory: Optional[
+            Callable[[asyncio.AbstractEventLoop, Generator[Any, None, _T]], asyncio.Future[_T]]
+        ],
+    ) -> None: ...
+    def get_task_factory(
+        self,
+    ) -> Optional[
+        Callable[[asyncio.AbstractEventLoop, Generator[Any, None, _T]], asyncio.Future[_T]]
+    ]: ...
+    @overload
+    def run_until_complete(self, future: Generator[Any, None, _T]) -> _T: ...
+    @overload
+    def run_until_complete(self, future: Awaitable[_T]) -> _T: ...
+    async def getaddrinfo(
+        self,
+        host: Optional[Union[str, bytes]],
+        port: Optional[Union[str, bytes, int]],
+        *,
+        family: int = ...,
+        type: int = ...,
+        proto: int = ...,
+        flags: int = ...,
+    ) -> List[
+        Tuple[
+            AddressFamily,
+            SocketKind,
+            int,
+            str,
+            Union[Tuple[str, int], Tuple[str, int, int, int]],
+        ]
+    ]: ...
+    async def getnameinfo(
+        self,
+        sockaddr: Union[
+            Tuple[str, int],
+            Tuple[str, int, int],
+            Tuple[str, int, int, int]
+        ],
+        flags: int = ...,
+    ) -> Tuple[str, str]: ...
+    async def start_tls(
+        self,
+        transport: asyncio.BaseTransport,
+        protocol: asyncio.BaseProtocol,
+        sslcontext: ssl.SSLContext,
+        *,
+        server_side: bool = ...,
+        server_hostname: Optional[str] = ...,
+        ssl_handshake_timeout: Optional[float] = ...,
+        ssl_shutdown_timeout: Optional[float] = ...,
+    ) -> asyncio.BaseTransport: ...
+    @overload
+    async def create_server(
+        self,
+        protocol_factory: asyncio.events._ProtocolFactory,
+        host: Optional[Union[str, Sequence[str]]] = ...,
+        port: int = ...,
+        *,
+        family: int = ...,
+        flags: int = ...,
+        sock: None = ...,
+        backlog: int = ...,
+        ssl: _SSLContext = ...,
+        reuse_address: Optional[bool] = ...,
+        reuse_port: Optional[bool] = ...,
+        ssl_handshake_timeout: Optional[float] = ...,
+        ssl_shutdown_timeout: Optional[float] = ...,
+        start_serving: bool = ...,
+    ) -> asyncio.AbstractServer: ...
+    @overload
+    async def create_server(
+        self,
+        protocol_factory: asyncio.events._ProtocolFactory,
+        host: None = ...,
+        port: None = ...,
+        *,
+        family: int = ...,
+        flags: int = ...,
+        sock: socket = ...,
+        backlog: int = ...,
+        ssl: _SSLContext = ...,
+        reuse_address: Optional[bool] = ...,
+        reuse_port: Optional[bool] = ...,
+        ssl_handshake_timeout: Optional[float] = ...,
+        ssl_shutdown_timeout: Optional[float] = ...,
+        start_serving: bool = ...,
+    ) -> asyncio.AbstractServer: ...
+    @overload
+    async def create_connection(
+        self,
+        protocol_factory: asyncio.events._ProtocolFactory,
+        host: str = ...,
+        port: int = ...,
+        *,
+        ssl: _SSLContext = ...,
+        family: int = ...,
+        proto: int = ...,
+        flags: int = ...,
+        sock: None = ...,
+        local_addr: Optional[Tuple[str, int]] = ...,
+        server_hostname: Optional[str] = ...,
+        ssl_handshake_timeout: Optional[float] = ...,
+        ssl_shutdown_timeout: Optional[float] = ...,
+    ) -> asyncio.events._TransProtPair: ...
+    @overload
+    async def create_connection(
+        self,
+        protocol_factory: asyncio.events._ProtocolFactory,
+        host: None = ...,
+        port: None = ...,
+        *,
+        ssl: _SSLContext = ...,
+        family: int = ...,
+        proto: int = ...,
+        flags: int = ...,
+        sock: socket,
+        local_addr: None = ...,
+        server_hostname: Optional[str] = ...,
+        ssl_handshake_timeout: Optional[float] = ...,
+        ssl_shutdown_timeout: Optional[float] = ...,
+    ) -> asyncio.events._TransProtPair: ...
+    async def create_unix_server(
+        self,
+        protocol_factory: asyncio.events._ProtocolFactory,
+        path: Optional[str] = ...,
+        *,
+        backlog: int = ...,
+        sock: Optional[socket] = ...,
+        ssl: _SSLContext = ...,
+        ssl_handshake_timeout: Optional[float] = ...,
+        ssl_shutdown_timeout: Optional[float] = ...,
+        start_serving: bool = ...,
+    ) -> asyncio.AbstractServer: ...
+    async def create_unix_connection(
+        self,
+        protocol_factory: asyncio.events._ProtocolFactory,
+        path: Optional[str] = ...,
+        *,
+        ssl: _SSLContext = ...,
+        sock: Optional[socket] = ...,
+        server_hostname: Optional[str] = ...,
+        ssl_handshake_timeout: Optional[float] = ...,
+        ssl_shutdown_timeout: Optional[float] = ...,
+    ) -> asyncio.events._TransProtPair: ...
+    def default_exception_handler(self, context: _Context) -> None: ...
+    def get_exception_handler(self) -> Optional[_ExceptionHandler]: ...
+    def set_exception_handler(self, handler: Optional[_ExceptionHandler]) -> None: ...
+    def call_exception_handler(self, context: _Context) -> None: ...
+    def add_reader(self, fd: Any, callback: Callable[..., Any], *args: Any) -> None: ...
+    def remove_reader(self, fd: Any) -> None: ...
+    def add_writer(self, fd: Any, callback: Callable[..., Any], *args: Any) -> None: ...
+    def remove_writer(self, fd: Any) -> None: ...
+    async def sock_recv(self, sock: socket, nbytes: int) -> bytes: ...
+    async def sock_recv_into(self, sock: socket, buf: bytearray) -> int: ...
+    async def sock_sendall(self, sock: socket, data: bytes) -> None: ...
+    async def sock_accept(self, sock: socket) -> Tuple[socket, _RetAddress]: ...
+    async def sock_connect(self, sock: socket, address: _Address) -> None: ...
+    async def connect_accepted_socket(
+        self,
+        protocol_factory: asyncio.events._ProtocolFactory,
+        sock: socket,
+        *,
+        ssl: _SSLContext = ...,
+        ssl_handshake_timeout: Optional[float] = ...,
+        ssl_shutdown_timeout: Optional[float] = ...,
+    ) -> asyncio.events._TransProtPair: ...
+    async def run_in_executor(
+        self, executor: Any, func: Callable[..., _T], *args: Any
+    ) -> _T: ...
+    def set_default_executor(self, executor: Any) -> None: ...
+    async def subprocess_shell(
+        self,
+        protocol_factory: asyncio.events._ProtocolFactory,
+        cmd: Union[bytes, str],
+        *,
+        stdin: Any = ...,
+        stdout: Any = ...,
+        stderr: Any = ...,
+        **kwargs: Any,
+    ) -> asyncio.events._TransProtPair: ...
+    async def subprocess_exec(
+        self,
+        protocol_factory: asyncio.events._ProtocolFactory,
+        *args: Any,
+        stdin: Any = ...,
+        stdout: Any = ...,
+        stderr: Any = ...,
+        **kwargs: Any,
+    ) -> asyncio.events._TransProtPair: ...
+    async def connect_read_pipe(
+        self, protocol_factory: asyncio.events._ProtocolFactory, pipe: Any
+    ) -> asyncio.events._TransProtPair: ...
+    async def connect_write_pipe(
+        self, protocol_factory: asyncio.events._ProtocolFactory, pipe: Any
+    ) -> asyncio.events._TransProtPair: ...
+    def add_signal_handler(
+        self, sig: int, callback: Callable[..., Any], *args: Any
+    ) -> None: ...
+    def remove_signal_handler(self, sig: int) -> bool: ...
+    async def create_datagram_endpoint(
+        self,
+        protocol_factory: asyncio.events._ProtocolFactory,
+        local_addr: Optional[Tuple[str, int]] = ...,
+        remote_addr: Optional[Tuple[str, int]] = ...,
+        *,
+        family: int = ...,
+        proto: int = ...,
+        flags: int = ...,
+        reuse_address: Optional[bool] = ...,
+        reuse_port: Optional[bool] = ...,
+        allow_broadcast: Optional[bool] = ...,
+        sock: Optional[socket] = ...,
+    ) -> asyncio.events._TransProtPair: ...
+    async def shutdown_asyncgens(self) -> None: ...
+    async def shutdown_default_executor(self) -> None: ...
+    # Loop doesn't implement these, but since they are marked as abstract in typeshed,
+    # we have to put them in so mypy thinks the base methods are overridden
+    async def sendfile(
+        self,
+        transport: asyncio.BaseTransport,
+        file: IO[bytes],
+        offset: int = ...,
+        count: Optional[int] = ...,
+        *,
+        fallback: bool = ...,
+    ) -> int: ...
+    async def sock_sendfile(
+        self,
+        sock: socket,
+        file: IO[bytes],
+        offset: int = ...,
+        count: Optional[int] = ...,
+        *,
+        fallback: bool = ...
+    ) -> int: ...


### PR DESCRIPTION
This PR adds typings for use with type checkers like `mypy`. Overall, this was fairly easy but two errors have to be suppressed with a `# type: ignore` comment:

* `remove_signal_handler()` returns a `bool` and typeshed has this method returning `None` in `AbstractEventLoop`. This seems to be an error in typeshed since the [docs](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.remove_signal_handler) state it should return a bool.
* `create_connection()` in Python 3.8+ accepts two new arguments (`happy_eyeballs_delay` and `interleave`) and since `uvloop.Loop.create_connection()` doesn't allow those arguments, the two methods are incompatible. This may be unavoidable.

References #358