### PR TITLE
Fix TypeError('cancel() takes exactly one argument (2 given)') with Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: generic
 env:
     global:
         - PYMODULE=uvloop
-        - RELEASE_PYTHON_VERSIONS="3.5 3.6 3.7 3.8"
+        - RELEASE_PYTHON_VERSIONS="3.5 3.6 3.7 3.8 3.9"
 
         - S3_UPLOAD_USERNAME=oss-ci-bot
         - S3_UPLOAD_BUCKET=magicstack-oss-releases
@@ -50,6 +50,11 @@ matrix:
           env: BUILD=tests,wheels PYTHON_VERSION=3.8.0
           branches: {only: [releases]}
 
+        - os: osx
+          osx_image: xcode7.3
+          env: BUILD=tests,wheels PYTHON_VERSION=3.9.0
+          branches: {only: [releases]}
+
         - os: linux
           dist: trusty
           language: python
@@ -72,6 +77,12 @@ matrix:
           dist: xenial
           language: python
           python: "3.8"
+          env: BUILD=tests
+
+        - os: linux
+          dist: bionic
+          language: python
+          python: "3.9"
           env: BUILD=tests
 
         - os: linux

--- a/uvloop/cbhandles.pyx
+++ b/uvloop/cbhandles.pyx
@@ -163,7 +163,7 @@ cdef class Handle:
 
         return '<' + ' '.join(info) + '>'
 
-    def cancel(self):
+    def cancel(self, msg=None):
         self._cancel()
 
     def cancelled(self):
@@ -321,7 +321,7 @@ cdef class TimerHandle:
     def cancelled(self):
         return self._cancelled
 
-    def cancel(self):
+    def cancel(self, msg=None):
         self._cancel()
 
 

--- a/uvloop/loop.pyx
+++ b/uvloop/loop.pyx
@@ -3190,7 +3190,7 @@ class _SyncSocketReaderFuture(aio_Future):
         self.__sock = sock
         self.__loop = loop
 
-    def cancel(self):
+    def cancel(self, msg=None):
         if self.__sock is not None and self.__sock.fileno() != -1:
             self.__loop.remove_reader(self.__sock)
             self.__sock = None
@@ -3205,7 +3205,7 @@ class _SyncSocketWriterFuture(aio_Future):
         self.__sock = sock
         self.__loop = loop
 
-    def cancel(self):
+    def cancel(self, msg=None):
         if self.__sock is not None and self.__sock.fileno() != -1:
             self.__loop.remove_writer(self.__sock)
             self.__sock = None

--- a/uvloop/request.pxd
+++ b/uvloop/request.pxd
@@ -5,4 +5,4 @@ cdef class UVRequest:
         Loop loop
 
     cdef on_done(self)
-    cdef cancel(self)
+    cdef cancel(self, msg=*)

--- a/uvloop/request.pyx
+++ b/uvloop/request.pyx
@@ -17,7 +17,7 @@ cdef class UVRequest:
         self.done = 1
         Py_DECREF(self)
 
-    cdef cancel(self):
+    cdef cancel(self, msg=None):
         # Most requests are implemented using a threadpool.  It's only
         # possible to cancel a request when it's still in a threadpool's
         # queue.  Once it's started to execute, we have to wait until


### PR DESCRIPTION
This fix #361