### PR TITLE
Automagically build wheels and push to pypi

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,13 +7,16 @@ jobs:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
 
     env:
       CIBW_BUILD: cp3?-*
-      CIBW_BEFORE_BUILD: pip install cython && make
+      CIBW_BEFORE_ALL: pip install Cython && make
+      CIBW_BEFORE_BUILD: pip install Cython
       CIBW_BUILD_VERBOSITY: 2
+      MACOSX_DEPLOYMENT_TARGET: "10.14"
 
     steps:
     - uses: actions/checkout@v2
@@ -28,6 +31,11 @@ jobs:
     - name: Install cibuildwheel
       run: |
         python -m pip install cibuildwheel
+
+    - name: Install autotools on MacOS
+      run: |
+        brew install automake
+      if: runner.os == 'macOS'
 
     - name: Build wheels
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,10 +71,12 @@ jobs:
   upload_pypi:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
+
     # upload to PyPI on every tag starting with 'v'
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
     # alternatively, to publish when a GitHub Release is created, use the following rule:
     # if: github.event_name == 'release' && github.event.action == 'published'
+
     steps:
     - uses: actions/download-artifact@v2
       with:
@@ -86,6 +88,4 @@ jobs:
         user: __token__
         password: ${{ secrets.pypi_password }}
         # to test:
-        repository_url: https://test.pypi.org/legacy/
-      if: >
-        startsWith(github.ref, 'refs/tags/v')
+        # repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    env:
+      CIBW_BUILD: cp3?-*
+      CIBW_BEFORE_BUILD: pip install cython && make
+      CIBW_BUILD_VERBOSITY: 2
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - uses: actions/setup-python@v2
+      name: Install Python
+      with:
+        python-version: '3.8'
+
+    - name: Install cibuildwheel
+      run: |
+        python -m pip install cibuildwheel
+
+    - name: Build wheels
+      run: |
+        python -m cibuildwheel --output-dir wheelhouse
+
+    - uses: actions/upload-artifact@v2
+      with:
+        path: ./wheelhouse/*.whl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,3 +44,27 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - uses: actions/setup-python@v2
+      name: Install Python
+      with:
+        python-version: '3.8'
+
+    - name: Install Cython
+      run: pip install Cython
+
+    - name: Build sdist
+      run: python setup.py sdist
+
+    - uses: actions/upload-artifact@v2
+      with:
+        path: dist/*.tar.gz
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,3 +68,24 @@ jobs:
       with:
         path: dist/*.tar.gz
 
+  upload_pypi:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    # upload to PyPI on every tag starting with 'v'
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+    # alternatively, to publish when a GitHub Release is created, use the following rule:
+    # if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+    - uses: actions/download-artifact@v2
+      with:
+        name: artifact
+        path: dist
+
+    - uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_password }}
+        # to test:
+        repository_url: https://test.pypi.org/legacy/
+      if: >
+        startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
Through the magic of Joe Rickerby's excellent joerick/cibuildwheel, we can now build wheels for python 3.5 - 3.9 for Linux and MacOS (Big Sur can be chosen but I think still won't build).

Also, if [0.15][2] is still far down the line, I can rebase over and target the 0.14 branch. Then we'd just need to e.g recreate the tag to push the updated wheels (including for python 3.9), and rebase or cherry pick the feature into master (and any branch that is still supported).

Either way, before merging, please make sure github secrets includes your pypi token password (although the upload happens upon tagging, it's better to do it sooner rather than later).

For an example on how this looks in action, check out [the last build in my fork][3], which produced [these pypi downloads][4] once a tag is pushed.

By the way, since a CI test build was added, we can probably avoid unnecessary builds, and only make wheels on releases, like [matplotlib does][1]: 

```yaml
on:
  push:
    branches:
      - master
      - v[0-9]+.[0-9]+.x
    tags:
      - v*
```

- [ ] squash all / fixup commits
- [ ] set pypi token secret

fixes #362


[1]: https://github.com/matplotlib/matplotlib/blob/7a5458b9a8cf3e4b7d1c471ad755d65ac5660b35/.github/workflows/cibuildwheel.yml#L3-L9
[2]: https://github.com/MagicStack/uvloop/projects/1
[3]: https://github.com/asfaltboy/uvloop/actions/runs/417772632
[4]: https://test.pypi.org/project/uvloop/#files