### PR TITLE
Fix future issue in sock_connect()

### DIFF
--- a/uvloop/loop.pyx
+++ b/uvloop/loop.pyx
@@ -1059,7 +1059,8 @@ cdef class Loop:
         return fut
 
     cdef _sock_connect_cb(self, fut, sock, address):
-        if fut.cancelled():
+        if fut.done():
+            # Refs #378: this may be called multiple times.
             return
 
         try:

--- a/uvloop/loop.pyx
+++ b/uvloop/loop.pyx
@@ -975,7 +975,7 @@ cdef class Loop:
 
         if UVLOOP_DEBUG:
             if fut.cancelled():
-                # Shouldn't happen with _SyncSocketReaderFuture.
+                # Shouldn't happen with _SyncSocketWriterFuture.
                 raise RuntimeError(
                     f'_sock_sendall is called on a cancelled Future')
 


### PR DESCRIPTION
Seems like, under pressure, more write callbacks may happen before `_remove_writer()` is called, so we should check for `done()` instead of `cancelled()`. I could reproduce this reliably on Linux with @Catstyle's script, and this PR does fix the issue. I tried to hack in a test but it wasn't easy at all (somehow libuv `uv_poll_t` could fire multiple times in a single event loop, while we're expecting `uv_idle_t` to step in immediately in the next loop to remove the `uv_poll_t`)

* Fixes #378
* CPython fixed the same issue in python/cpython#10419