### PR TITLE
Use hard-coded FD for stdio in subprocess

### DIFF
--- a/uvloop/handles/process.pyx
+++ b/uvloop/handles/process.pyx
@@ -452,7 +452,7 @@ cdef class UVProcessTransport(UVProcess):
             else:
                 io[0] = self._file_redirect_stdio(_stdin)
         else:
-            io[0] = self._file_redirect_stdio(sys.stdin.fileno())
+            io[0] = self._file_redirect_stdio(0)
 
         if _stdout is not None:
             if _stdout == subprocess_PIPE:
@@ -480,7 +480,7 @@ cdef class UVProcessTransport(UVProcess):
             else:
                 io[1] = self._file_redirect_stdio(_stdout)
         else:
-            io[1] = self._file_redirect_stdio(sys.stdout.fileno())
+            io[1] = self._file_redirect_stdio(1)
 
         if _stderr is not None:
             if _stderr == subprocess_PIPE:
@@ -508,7 +508,7 @@ cdef class UVProcessTransport(UVProcess):
             else:
                 io[2] = self._file_redirect_stdio(_stderr)
         else:
-            io[2] = self._file_redirect_stdio(sys.stderr.fileno())
+            io[2] = self._file_redirect_stdio(2)
 
         assert len(io) == 3
         for idx in range(3):


### PR DESCRIPTION
Use FD=0/1/2 for `subprocess(stdin=None, stdout=None, stderr=None)`. This aligns uvloop with the same behavior in asyncio - when stdin, stdout or stderr is None, the subprocess will use FD 0, 1 or 2 now instead of `sys.stdin`, `sys.stdout` or `sys.stderr`.

asyncio eventually calls [this](https://github.com/python/cpython/blob/d65b9033d6d092552775f6f5e41e7647100f9f2c/Modules/_posixsubprocess.c#L547-L569) to create subprocess, where `p2cread`, `c2pwrite` or `errwrite` are `-1` and the current FD 0, 1 and 2 are left untouched to eventually call `execv()`.

Fixes #136

- [x] Add test
- [x] Add description
- [x] Fix commit message