### PR TITLE
Remove deprecated setup.py test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,8 @@ docs:
 
 
 test:
-	PYTHONASYNCIODEBUG=1 $(PYTHON) setup.py test
-	$(PYTHON) setup.py test
+	PYTHONASYNCIODEBUG=1 $(PYTHON) -m unittest -v tests.suite
+	$(PYTHON) -m unittest -v tests.suite
 
 
 testinstalled:

--- a/setup.py
+++ b/setup.py
@@ -316,7 +316,6 @@ setup(
         'Intended Audience :: Developers',
     ],
     include_package_data=True,
-    test_suite='tests.suite',
     extras_require=EXTRA_DEPENDENCIES,
     setup_requires=setup_requires
 )


### PR DESCRIPTION
Refs pypa/setuptools#1684, `setup.py test` is deprecated since [setuptools v41.5.0](https://setuptools.readthedocs.io/en/latest/history.html#v41-5-0).