### PR TITLE
set python_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -317,5 +317,6 @@ setup(
     ],
     include_package_data=True,
     extras_require=EXTRA_DEPENDENCIES,
-    setup_requires=setup_requires
+    setup_requires=setup_requires,
+    python_requires='>=3.7',
 )


### PR DESCRIPTION
currently when installing uvloop (without pins) pip on py3.6 will download 0.15.1 and then fail. Setting requires_python means pip can pick a different version to install

0.15.0 and 0.15.1 will need to be yanked to avoid issues like https://github.com/encode/uvicorn/issues/953