### PR TITLE
Bump minimum required Cython version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from setuptools.command.build_ext import build_ext as build_ext
 from setuptools.command.sdist import sdist as sdist
 
 
-CYTHON_DEPENDENCY = 'Cython(>=0.29.20,<0.30.0)'
+CYTHON_DEPENDENCY = 'Cython(>=0.29.24,<0.30.0)'
 
 # Minimal dependencies required to test uvloop.
 TEST_DEPENDENCIES = [

--- a/tests/test_cython.py
+++ b/tests/test_cython.py
@@ -11,8 +11,11 @@ class TestCythonIntegration(UVTestCase):
 
         coro = _test_coroutine_1()
 
+        coro_fmt = _format_coroutine(coro)
         self.assertTrue(
-            _format_coroutine(coro).startswith('_test_coroutine_1() done'))
+            coro_fmt.startswith('_test_coroutine_1() done')
+            or coro_fmt.startswith('_test_coroutine_1() running')
+        )
         self.assertEqual(_test_coroutine_1.__qualname__, '_test_coroutine_1')
         self.assertEqual(_test_coroutine_1.__name__, '_test_coroutine_1')
         self.assertTrue(asyncio.iscoroutine(coro))


### PR DESCRIPTION
0.29.24 is needed to compile properly under Python 3.10