### PR TITLE
uvloop v0.16.0

### DIFF
--- a/uvloop/_version.py
+++ b/uvloop/_version.py
@@ -10,4 +10,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = '0.16.0.dev0'
+__version__ = '0.16.0'


### PR DESCRIPTION
This release adds Python 3.10 support, updates bundled libuv to 1.42.0
and fixes a handful of issues.

Changes
=======

* Python 3.10 support (#432)
  (by @elprans in 2519e2df for #432)

* Bump vendored libuv to 1.42.0 (#433)
  (by @elprans in a62f7818 for #433)

* Use cibuildwheel to build wheels (#435)
  (by @elprans in 20febe0b for #435)

* Add support for `<timer handle>.when()`
  (by Jens Jorgensen in 62b2af9c)

Fixes
=====

* Fix ref issue when protocol is in Cython
  (by @fantix in 70cafc82 for #2222)

* Set `python_requires` in setup.py
  (by @graingert in c808a663)

* SSL: schedule first data after waiter wakeup
  (by @fantix in 2081db89)

* Fix a possible race condition in sslproto test
  (by @fantix in b0526cd5 for #412)

* Fix `call_soon_threadsafe` thread safety
  (by @fantix in 4b803b15)