### PR TITLE
setup.py: append environment CFLAGS to local CFLAGS variable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,8 @@ def _libuv_build_env():
 
     env['CFLAGS'] = (cur_cflags + ' -fPIC ' + env.get('ARCHFLAGS', ''))
 
+    CFLAGS += env['CFLAGS']
+
     return env
 
 


### PR DESCRIPTION
Please check build failure [1] due to toolchain m68k infinite loop if -O2 is passed.
There we need to override it with -O0 and the only way I've found is the on in the patch.

[1]: http://autobuild.buildroot.net/results/17d/17d6e6422abadcd6313c430c40f2a5d7162dbbd3/build-end.log
