### PR TITLE
setup.py: allow to override extra_compile_args

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ EXTRA_DEPENDENCIES = {
 
 
 MACHINE = platform.machine()
-CFLAGS = ['-O2']
+MODULES_CFLAGS = [os.getenv('MODULES_CFLAGS', '-O2')]
 _ROOT = pathlib.Path(__file__).parent
 LIBUV_DIR = str(_ROOT / 'vendor' / 'libuv')
 LIBUV_BUILD_DIR = str(_ROOT / 'build' / 'libuv-{}'.format(MACHINE))
@@ -301,7 +301,7 @@ setup(
             sources=[
                 "uvloop/loop.pyx",
             ],
-            extra_compile_args=CFLAGS
+            extra_compile_args=MODULES_CFLAGS
         ),
     ],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ EXTRA_DEPENDENCIES = {
 
 
 MACHINE = platform.machine()
-MODULES_CFLAGS = [os.getenv('MODULES_CFLAGS', '-O2')]
+MODULES_CFLAGS = [os.getenv('UVLOOP_OPT_CFLAGS', '-O2')]
 _ROOT = pathlib.Path(__file__).parent
 LIBUV_DIR = str(_ROOT / 'vendor' / 'libuv')
 LIBUV_BUILD_DIR = str(_ROOT / 'build' / 'libuv-{}'.format(MACHINE))


### PR DESCRIPTION
At the moment extra_compile_args is set to -O2 by default. But m68k
toolchain has a bug that when trying to build Extension uvloop.loop enters
an infinite loop[1]. So we need to override -O2 with -O0 to make it
work. So let's getenv('MODULES_CFLAGS') and assign it to local
MODULES_CFLAGS (former CFLAGS) and assign it to extra_compile_args. If
not MODULES_CFLAGS is found then -O2 is kept as default.

[1]: http://autobuild.buildroot.net/results/17d/17d6e6422abadcd6313c430c40f2a5d7162dbbd3/build-end.log

Signed-off-by: Giulio Benetti <giulio.benetti@benettiengineering.com>