### PR TITLE
Version bump of cibuildwheel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
       run: |
         brew install gnu-sed libtool autoconf automake
 
-    - uses: pypa/cibuildwheel@v2.1.1
+    - uses: pypa/cibuildwheel@v2.2.0
       env:
         CIBW_BUILD_VERBOSITY: 1
         CIBW_BUILD: ${{ matrix.cibw_python }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
       run: |
         brew install gnu-sed libtool autoconf automake
 
-    - uses: pypa/cibuildwheel@v2.2.0
+    - uses: pypa/cibuildwheel@v2.2.2
       env:
         CIBW_BUILD_VERBOSITY: 1
         CIBW_BUILD: ${{ matrix.cibw_python }}


### PR DESCRIPTION
Update cibuildwheel to 2.2.0, which will enable musllinux wheel builds. This is useful for environments like alpine linux containers.