### PR TITLE
fix incorrect main thread id value in mp.Process 

### DIFF
--- a/uvloop/includes/fork_handler.h
+++ b/uvloop/includes/fork_handler.h
@@ -1,3 +1,5 @@
+volatile uint64_t MAIN_THREAD_ID = 0;
+volatile int8_t MAIN_THREAD_ID_SET = 0;
 
 typedef void (*OnForkHandler)();
 
@@ -9,6 +11,10 @@ Note: Fork handler needs to be in C (not cython) otherwise it would require
 GIL to be present, but some forks can exec non-python processes.
 */
 void handleAtFork(void) {
+    // Reset the MAIN_THREAD_ID on fork, because the main thread ID is not
+    // always the same after fork, especially when forked from within a thread.
+    MAIN_THREAD_ID_SET = 0;
+
     if (__forkHandler != NULL) {
         __forkHandler();
     }
@@ -24,4 +30,9 @@ void setForkHandler(OnForkHandler handler)
 void resetForkHandler(void)
 {
     __forkHandler = NULL;
+}
+
+void setMainThreadID(uint64_t id) {
+    MAIN_THREAD_ID = id;
+    MAIN_THREAD_ID_SET = 1;
 }

--- a/uvloop/includes/stdlib.pxi
+++ b/uvloop/includes/stdlib.pxi
@@ -135,8 +135,8 @@ cdef int ssl_SSL_ERROR_WANT_READ = ssl.SSL_ERROR_WANT_READ
 cdef int ssl_SSL_ERROR_WANT_WRITE = ssl.SSL_ERROR_WANT_WRITE
 cdef int ssl_SSL_ERROR_SYSCALL = ssl.SSL_ERROR_SYSCALL
 
-cdef uint64_t MAIN_THREAD_ID = <uint64_t><int64_t>threading.main_thread().ident
 cdef threading_Thread = threading.Thread
+cdef threading_main_thread = threading.main_thread
 
 cdef int subprocess_PIPE = subprocess.PIPE
 cdef int subprocess_STDOUT = subprocess.STDOUT

--- a/uvloop/includes/system.pxd
+++ b/uvloop/includes/system.pxd
@@ -1,3 +1,5 @@
+from libc.stdint cimport int8_t, uint64_t
+
 cdef extern from "arpa/inet.h" nogil:
 
     int ntohl(int)
@@ -85,7 +87,10 @@ cdef extern from "includes/compat.h" nogil:
 
 cdef extern from "includes/fork_handler.h":
 
+    uint64_t MAIN_THREAD_ID
+    int8_t MAIN_THREAD_ID_SET
     ctypedef void (*OnForkHandler)()
     void handleAtFork()
     void setForkHandler(OnForkHandler handler)
     void resetForkHandler()
+    void setMainThreadID(uint64_t id)

--- a/uvloop/loop.pxd
+++ b/uvloop/loop.pxd
@@ -44,7 +44,6 @@ cdef class Loop:
         bint _stopping
 
         uint64_t _thread_id
-        bint _thread_is_main
 
         object _task_factory
         object _exception_handler

--- a/uvloop/loop.pyx
+++ b/uvloop/loop.pyx
@@ -215,7 +215,11 @@ cdef class Loop:
         self._servers = set()
 
     cdef inline _is_main_thread(self):
-        return threading_main_thread().ident == PyThread_get_thread_ident()
+        cdef uint64_t main_thread_id = system.MAIN_THREAD_ID
+        if system.MAIN_THREAD_ID_SET == 0:
+            main_thread_id = <uint64_t><int64_t>threading_main_thread().ident
+            system.setMainThreadID(main_thread_id)
+        return main_thread_id == PyThread_get_thread_ident()
 
     def __init__(self):
         self.set_debug((not sys_ignore_environment


### PR DESCRIPTION
fixes #452

MAIN_THREAD_ID had incorrect value when you run uvloop in subprocess. So it was affecting `_setup_or_resume_signals`. Subprocess is runned via `multiprocessing.Process` and should be closed by signal. However subprocess gets signal and stucks in eternal loop.