### PR TITLE
create_subprocess_exec should treat env={} as empty environment (#439)

### DIFF
--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -49,6 +49,22 @@ class _TestProcess:
 
         self.loop.run_until_complete(test())
 
+    def test_process_env_2(self):
+        async def test():
+            cmd = 'env'
+            env = {}  # empty environment
+            proc = await asyncio.create_subprocess_exec(
+                cmd,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE)
+
+            out, _ = await proc.communicate()
+            self.assertEqual(out, b'')
+            self.assertEqual(proc.returncode, 0)
+
+        self.loop.run_until_complete(test())
+
     def test_process_cwd_1(self):
         async def test():
             cmd = 'pwd'

--- a/uvloop/handles/process.pyx
+++ b/uvloop/handles/process.pyx
@@ -217,9 +217,6 @@ cdef class UVProcess(UVHandle):
 
             char **ret
 
-        if UVLOOP_DEBUG:
-            assert arr_len > 0
-
         ret = <char **>PyMem_RawMalloc((arr_len + 1) * sizeof(char *))
         if ret is NULL:
             raise MemoryError()

--- a/uvloop/handles/process.pyx
+++ b/uvloop/handles/process.pyx
@@ -288,7 +288,7 @@ cdef class UVProcess(UVHandle):
         self.uv_opt_args = self.__to_cstring_array(self.__args)
 
     cdef _init_env(self, dict env):
-        if env is not None and len(env):
+        if env is not None:
             self.__env = list()
             for key in env:
                 val = env[key]


### PR DESCRIPTION
Fixes #439