### PR TITLE
Run tests against Python 3.10 stable

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10.0-rc.1]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         os: [ubuntu-latest, macos-latest]
 
     env:


### PR DESCRIPTION
`3.10` without quotes is interpreted as `3.1` (float).