### PR TITLE
Fix CI badge in docs, remove remaining Travis CI references from docs

### DIFF
--- a/docs/dev/index.rst
+++ b/docs/dev/index.rst
@@ -2,7 +2,7 @@ Developers Guide
 ================
 
 The project is hosted on `GitHub <https://github.com/MagicStack/uvloop>`_.
-and uses `Travis <https://travis-ci.org/MagicStack/uvloop>`_ for
+and uses `GitHub Actions <https://github.com/MagicStack/uvloop/actions>`_ for
 Continuous Integration.
 
 A goal for the `uvloop` project is to provide a drop in replacement for the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
-.. image:: https://travis-ci.org/MagicStack/uvloop.svg?branch=master
-    :target: https://travis-ci.org/MagicStack/uvloop
+.. image:: https://img.shields.io/github/workflow/status/MagicStack/uvloop/Tests
+    :target: https://github.com/MagicStack/uvloop/actions?query=workflow%3ATests+branch%3Amaster
 
 .. image:: https://img.shields.io/pypi/status/uvloop.svg?maxAge=2592000?style=plastic
     :target: https://pypi.python.org/pypi/uvloop


### PR DESCRIPTION
#397 only updated the readme but not the badge shown at https://uvloop.readthedocs.io or the info about the CI env in developer docs