### PR TITLE
avoid self._errpipe_write double close

### DIFF
--- a/uvloop/handles/process.pyx
+++ b/uvloop/handles/process.pyx
@@ -101,6 +101,7 @@ cdef class UVProcess(UVHandle):
             self._finish_init()
 
             os_close(self._errpipe_write)
+            self._errpipe_write = -1
 
             if preexec_fn is not None:
                 errpipe_data = bytearray()


### PR DESCRIPTION
Fixes #414

the I couldn't get the original MRE from the issue https://gist.github.com/decorator-factory/6b5276ab5fb87f4c009f1d22dc4b20a9 to always fail - it seems to be intermittent. However the following *always* fails for me without this patch:

```python
import os
import asyncio
import subprocess

import uvloop
uvloop.install()


async def main():
    done = False
    def preexec_fn():
        pass

    async def fork():
        nonlocal done
        try:
            for i in range(1000):
                await asyncio.sleep(0)
                try:
                    proc = await asyncio.create_subprocess_exec("true", preexec_fn=preexec_fn)
                    await proc.communicate()
                except subprocess.SubprocessError:
                    print("done")
        finally:
            done = True

    def write_file():
        while not done:
            with open("demo", "w") as f:
                f.write("hello")
                print(f.fileno())

    await asyncio.gather(
        fork(),
        asyncio.to_thread(write_file)
    )

asyncio.run(main())
```