### PR TITLE
use a stack of self._fds_to_close to prevent double closes

### DIFF
--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -797,69 +797,58 @@ print(n)'''
 
 
 class Test_UV_Process(_TestProcess, tb.UVTestCase):
-    def test_process_preexec_fn_double_close(self):
+    def test_process_double_close(self):
         script = textwrap.dedent("""
             import os
             import sys
-            import threading
-            import queue
-            import concurrent.futures
-
-            pid = os.getpid()
-            q = queue.Queue()
-            evt = threading.Event()
-            r, w = os.pipe()
-            pipe = os.pipe
-            close = os.close
-
-
-            def mock_pipe():
-                rv = pipe()
-                q.put(rv[1])
-                return rv
-
-
-            def mock_close(fd):
-                close(fd)
-                if os.getpid() == pid:
-                    q.put(fd)
-                    evt.wait()
-
-
-            os.pipe = mock_pipe
-            os.close = mock_close
+            from unittest import mock
 
             import asyncio
-            import uvloop
 
-            uvloop.install()
+            pipes = []
+            original_os_pipe = os.pipe
+            def log_pipes():
+                pipe = original_os_pipe()
+                pipes.append(pipe)
+                return pipe
 
+            dups = []
+            original_os_dup = os.dup
+            def log_dups(*args, **kwargs):
+                dup = original_os_dup(*args, **kwargs)
+                dups.append(dup)
+                return dup
 
-            def thread():
-                fd = q.get()
-                while True:
-                    fd_close = q.get()
-                    if fd == fd_close:
-                        os.dup2(r, fd)
-                        evt.set()
-                        break
-                while os.read(fd, 32) != b"exit":
-                    pass
+            with mock.patch(
+                "os.close", wraps=os.close
+            ) as os_close, mock.patch(
+                "os.pipe", new=log_pipes
+            ), mock.patch(
+                "os.dup", new=log_dups
+            ):
+                import uvloop
 
 
             async def test():
-                await asyncio.create_subprocess_exec(
-                    sys.executable, "-c", "pass", preexec_fn=lambda: True
+                proc = await asyncio.create_subprocess_exec(
+                    sys.executable, "-c", "pass"
                 )
-                os.write(w, b"exit")
+                await proc.communicate()
 
+            uvloop.install()
+            asyncio.run(test())
 
-            with concurrent.futures.ThreadPoolExecutor() as executor:
-                fut = executor.submit(thread)
-                asyncio.run(test())
-                fut.result()
+            stdin, stdout, stderr = dups
+            (r, w), = pipes
+            assert os_close.mock_calls == [
+                mock.call(w),
+                mock.call(r),
+                mock.call(stderr),
+                mock.call(stdout),
+                mock.call(stdin),
+            ]
         """)
-        subprocess.check_call([sys.executable, '-c', script])
+        subprocess.run([sys.executable, '-c', script], check=True)
 
 
 class Test_AIO_Process(_TestProcess, tb.AIOTestCase):

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -856,7 +856,7 @@ class Test_UV_Process(_TestProcess, tb.UVTestCase):
 
             with concurrent.futures.ThreadPoolExecutor() as executor:
                 fut = executor.submit(thread)
-                asyncio.get_event_loop().run_until_complete(test())
+                asyncio.run(test())
                 fut.result()
         """)
         subprocess.check_call([sys.executable, '-c', script])

--- a/uvloop/handles/process.pxd
+++ b/uvloop/handles/process.pxd
@@ -8,7 +8,7 @@ cdef class UVProcess(UVHandle):
         object _preexec_fn
         bint _restore_signals
 
-        set _fds_to_close
+        list _fds_to_close
 
         # Attributes used to compose uv_process_options_t:
         uv.uv_process_options_t options

--- a/uvloop/handles/process.pyx
+++ b/uvloop/handles/process.pyx
@@ -72,6 +72,7 @@ cdef class UVProcess(UVHandle):
         fds_to_close = self._fds_to_close
         self._fds_to_close = None
         fds_to_close.append(self._errpipe_read)
+        # add the write pipe last so we can close it early
         fds_to_close.append(self._errpipe_write)
         try:
             os_set_inheritable(self._errpipe_write, True)

--- a/uvloop/handles/process.pyx
+++ b/uvloop/handles/process.pyx
@@ -496,10 +496,7 @@ cdef class UVProcessTransport(UVProcess):
                     # shouldn't ever happen
                     raise RuntimeError('cannot apply subprocess.STDOUT')
 
-                newfd = os_dup(io[1])
-                os_set_inheritable(newfd, True)
-                self._close_after_spawn(newfd)
-                io[2] = newfd
+                io[2] = self._file_redirect_stdio(io[1])
             elif _stderr == subprocess_DEVNULL:
                 io[2] = self._file_devnull()
             else:


### PR DESCRIPTION
and make tests easier to write because the close order is deterministic
and in the order that opens happen in

this should also be a bit faster because `list.append` is faster
than `set.add` and we skip a call to `os_close(-1)` and catching an
`OSError` exception