### PR TITLE
enable the cython binding=True directive

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -598,6 +598,16 @@ class _TestBase:
         self.loop.set_task_factory(None)
         self.assertIsNone(self.loop.get_task_factory())
 
+    def test_asyncgen_hooks(self):
+        async def get_asyncgens():
+            return sys.get_asyncgen_hooks()
+
+        # for sniffio to detect uvloop as asyncio efficiently the running loop
+        # call_soon module needs to match the asyncgen_hooks module
+        hooks = self.loop.run_until_complete(get_asyncgen_hooks)
+        self.assertEqual(hooks.finzalier.__module__, "uvloop.loop")
+        self.assertEqual(self.loop.call_soon.__module__, "uvloop.loop")
+
     def test_shutdown_asyncgens_01(self):
         finalized = list()
 

--- a/uvloop/loop.pxd
+++ b/uvloop/loop.pxd
@@ -1,4 +1,4 @@
-# cython: language_level=3
+# cython: language_level=3, embedsignature=True, binding=True
 
 
 from .includes cimport uv

--- a/uvloop/loop.pyx
+++ b/uvloop/loop.pyx
@@ -1,4 +1,4 @@
-# cython: language_level=3, embedsignature=True
+# cython: language_level=3, embedsignature=True, binding=True
 
 import asyncio
 cimport cython


### PR DESCRIPTION
it becomes the default in cython3 and is needed for sniffio
to detect uvloop as asyncio efficiently