### PR TITLE
Drop Python 3.6 support for thread ident

### DIFF
--- a/uvloop/loop.pyx
+++ b/uvloop/loop.pyx
@@ -218,7 +218,7 @@ cdef class Loop:
     cdef inline _is_main_thread(self):
         cdef uint64_t main_thread_id = system.MAIN_THREAD_ID
         if system.MAIN_THREAD_ID_SET == 0:
-            main_thread_id = <uint64_t><int64_t>threading_main_thread().ident
+            main_thread_id = <uint64_t>threading_main_thread().ident
             system.setMainThreadID(main_thread_id)
         return main_thread_id == PyThread_get_thread_ident()
 
@@ -711,7 +711,7 @@ cdef class Loop:
             return
 
         cdef uint64_t thread_id
-        thread_id = <uint64_t><int64_t>PyThread_get_thread_ident()
+        thread_id = <uint64_t>PyThread_get_thread_ident()
 
         if thread_id != self._thread_id:
             raise RuntimeError(


### PR DESCRIPTION
Python 3.6 uses `long` for thread ident, while 3.7 uses `unsigned long`. We converted the Python integer to `int64_t` to support 3.6 (Cython enforces the integer is not overflowing), but it broke 64bit 3.7+ as described in #427.

Now we don't support 3.6 anymore, we could drop this conversion and live happily with the Cython-checked `<uint64_t>` conversion.

Reverts b5b4abb in #172, and fixes #427