### PR TITLE
Fix loop.getaddrinfo() and tests

### DIFF
--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -130,10 +130,14 @@ class BaseTestDNS:
     def test_getaddrinfo_19(self):
         self._test_getaddrinfo('::1', 80)
         self._test_getaddrinfo('::1', 80, type=socket.SOCK_STREAM)
+        self._test_getaddrinfo('::1', 80, type=socket.SOCK_STREAM,
+                               flags=socket.AI_CANONNAME)
 
     def test_getaddrinfo_20(self):
         self._test_getaddrinfo('127.0.0.1', 80)
         self._test_getaddrinfo('127.0.0.1', 80, type=socket.SOCK_STREAM)
+        self._test_getaddrinfo('127.0.0.1', 80, type=socket.SOCK_STREAM,
+                               flags=socket.AI_CANONNAME)
 
     ######
 

--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -5,12 +5,32 @@ import unittest
 from uvloop import _testbase as tb
 
 
+def patched_getaddrinfo(*args, **kwargs):
+    # corrected socket.getaddrinfo() behavior: ai_canonname always follows the
+    # flag AI_CANONNAME, even if `host` is an IP
+    rv = []
+    result = socket.getaddrinfo(*args, **kwargs)
+    for af, sk, proto, canon_name, addr in result:
+        if kwargs.get('flags', 0) & socket.AI_CANONNAME:
+            if not canon_name:
+                canon_name = args[0]
+                if not isinstance(canon_name, str):
+                    canon_name = canon_name.decode('ascii')
+        elif canon_name:
+            canon_name = ''
+        rv.append((af, sk, proto, canon_name, addr))
+    return rv
+
+
 class BaseTestDNS:
 
-    def _test_getaddrinfo(self, *args, **kwargs):
+    def _test_getaddrinfo(self, *args, _patch=False, **kwargs):
         err = None
         try:
-            a1 = socket.getaddrinfo(*args, **kwargs)
+            if _patch:
+                a1 = patched_getaddrinfo(*args, **kwargs)
+            else:
+                a1 = socket.getaddrinfo(*args, **kwargs)
         except socket.gaierror as ex:
             err = ex
 
@@ -100,20 +120,36 @@ class BaseTestDNS:
         self._test_getaddrinfo(b'example.com', '80', type=socket.SOCK_STREAM)
 
     def test_getaddrinfo_12(self):
+        # musl always returns ai_canonname but we don't
+        patch = self.implementation != 'asyncio'
+
         self._test_getaddrinfo('127.0.0.1', '80')
-        self._test_getaddrinfo('127.0.0.1', '80', type=socket.SOCK_STREAM)
+        self._test_getaddrinfo('127.0.0.1', '80', type=socket.SOCK_STREAM,
+                               _patch=patch)
 
     def test_getaddrinfo_13(self):
+        # musl always returns ai_canonname but we don't
+        patch = self.implementation != 'asyncio'
+
         self._test_getaddrinfo(b'127.0.0.1', b'80')
-        self._test_getaddrinfo(b'127.0.0.1', b'80', type=socket.SOCK_STREAM)
+        self._test_getaddrinfo(b'127.0.0.1', b'80', type=socket.SOCK_STREAM,
+                               _patch=patch)
 
     def test_getaddrinfo_14(self):
+        # musl always returns ai_canonname but we don't
+        patch = self.implementation != 'asyncio'
+
         self._test_getaddrinfo(b'127.0.0.1', b'http')
-        self._test_getaddrinfo(b'127.0.0.1', b'http', type=socket.SOCK_STREAM)
+        self._test_getaddrinfo(b'127.0.0.1', b'http', type=socket.SOCK_STREAM,
+                               _patch=patch)
 
     def test_getaddrinfo_15(self):
+        # musl always returns ai_canonname but we don't
+        patch = self.implementation != 'asyncio'
+
         self._test_getaddrinfo('127.0.0.1', 'http')
-        self._test_getaddrinfo('127.0.0.1', 'http', type=socket.SOCK_STREAM)
+        self._test_getaddrinfo('127.0.0.1', 'http', type=socket.SOCK_STREAM,
+                               _patch=patch)
 
     def test_getaddrinfo_16(self):
         self._test_getaddrinfo('localhost', 'http')
@@ -128,16 +164,26 @@ class BaseTestDNS:
         self._test_getaddrinfo('localhost', b'http', type=socket.SOCK_STREAM)
 
     def test_getaddrinfo_19(self):
+        # musl always returns ai_canonname while macOS never return for IPs,
+        # but we strictly follow the docs to use the AI_CANONNAME flag
+        patch = self.implementation != 'asyncio'
+
         self._test_getaddrinfo('::1', 80)
-        self._test_getaddrinfo('::1', 80, type=socket.SOCK_STREAM)
         self._test_getaddrinfo('::1', 80, type=socket.SOCK_STREAM,
-                               flags=socket.AI_CANONNAME)
+                               _patch=patch)
+        self._test_getaddrinfo('::1', 80, type=socket.SOCK_STREAM,
+                               flags=socket.AI_CANONNAME, _patch=patch)
 
     def test_getaddrinfo_20(self):
+        # musl always returns ai_canonname while macOS never return for IPs,
+        # but we strictly follow the docs to use the AI_CANONNAME flag
+        patch = self.implementation != 'asyncio'
+
         self._test_getaddrinfo('127.0.0.1', 80)
-        self._test_getaddrinfo('127.0.0.1', 80, type=socket.SOCK_STREAM)
         self._test_getaddrinfo('127.0.0.1', 80, type=socket.SOCK_STREAM,
-                               flags=socket.AI_CANONNAME)
+                               _patch=patch)
+        self._test_getaddrinfo('127.0.0.1', 80, type=socket.SOCK_STREAM,
+                               flags=socket.AI_CANONNAME, _patch=patch)
 
     ######
 

--- a/tests/test_tcp.py
+++ b/tests/test_tcp.py
@@ -222,7 +222,7 @@ class _TestTCP:
 
             with self.assertRaisesRegex(OSError,
                                         r"error while attempting.*\('127.*: "
-                                        r"address already in use"):
+                                        r"address( already)? in use"):
 
                 self.loop.run_until_complete(
                     self.loop.create_server(object, *addr))

--- a/uvloop/dns.pyx
+++ b/uvloop/dns.pyx
@@ -224,28 +224,6 @@ cdef __static_getaddrinfo(object host, object port,
             return (family, type, proto)
 
 
-# This flag is used in __static_getaddrinfo_pyaddr() to manage
-# if ai_canonname should be returned when AI_CANONNAME flag is set,
-# because its behavior varies in different libc implementations (see #494).
-# This flag is lazily set in loop.getaddrinfo() to make sure that
-# __static_getaddrinfo_pyaddr() behaves consistently as libc getaddrinfo().
-cdef int __static_getaddrinfo_canonname_mode = 0
-
-# Bitmasks for __static_getaddrinfo_canonname_mode:
-
-# If STATIC_GETADDRINFO_CANONNAME_ON_RETURN is set
-cdef int STATIC_GETADDRINFO_CANONNAME_ON_BEHAVIOR_SET = 1 << 0
-
-# If ai_canonname should be returned when AI_CANONNAME is set
-cdef int STATIC_GETADDRINFO_CANONNAME_ON_RETURN = 1 << 1
-
-# If STATIC_GETADDRINFO_CANONNAME_OFF_RETURN is set
-cdef int STATIC_GETADDRINFO_CANONNAME_OFF_BEHAVIOR_SET = 1 << 2
-
-# If ai_canonname should be returned when AI_CANONNAME is not set
-cdef int STATIC_GETADDRINFO_CANONNAME_OFF_RETURN = 1 << 3
-
-
 cdef __static_getaddrinfo_pyaddr(object host, object port,
                                  int family, int type,
                                  int proto, int flags):
@@ -267,10 +245,7 @@ cdef __static_getaddrinfo_pyaddr(object host, object port,
     except Exception:
         return
 
-    if __static_getaddrinfo_canonname_mode & (
-        STATIC_GETADDRINFO_CANONNAME_ON_RETURN if flags & socket_AI_CANONNAME
-        else STATIC_GETADDRINFO_CANONNAME_OFF_RETURN
-    ):
+    if flags & socket_AI_CANONNAME:
         if isinstance(host, str):
             canon_name = host
         else:

--- a/uvloop/includes/stdlib.pxi
+++ b/uvloop/includes/stdlib.pxi
@@ -72,6 +72,7 @@ cdef int has_SO_REUSEPORT = hasattr(socket, 'SO_REUSEPORT')
 cdef int SO_REUSEPORT = getattr(socket, 'SO_REUSEPORT', 0)
 cdef int SO_BROADCAST = getattr(socket, 'SO_BROADCAST')
 cdef int SOCK_NONBLOCK = getattr(socket, 'SOCK_NONBLOCK', -1)
+cdef int socket_AI_CANONNAME = getattr(socket, 'AI_CANONNAME')
 
 cdef socket_gaierror = socket.gaierror
 cdef socket_error = socket.error

--- a/uvloop/loop.pyx
+++ b/uvloop/loop.pyx
@@ -1523,40 +1523,11 @@ cdef class Loop:
     @cython.iterable_coroutine
     async def getaddrinfo(self, object host, object port, *,
                           int family=0, int type=0, int proto=0, int flags=0):
-        global __static_getaddrinfo_canonname_mode
 
         addr = __static_getaddrinfo_pyaddr(host, port, family,
                                            type, proto, flags)
         if addr is not None:
-            if __static_getaddrinfo_canonname_mode & (
-                STATIC_GETADDRINFO_CANONNAME_ON_BEHAVIOR_SET
-                if flags & socket_AI_CANONNAME
-                else STATIC_GETADDRINFO_CANONNAME_OFF_BEHAVIOR_SET
-            ):
-                return [addr]
-
-            rv = await self._getaddrinfo(
-                host, port, family, type, proto, flags, 1)
-
-            _af, _type, _proto, canon_name, _addr = rv[0]
-            if flags & socket_AI_CANONNAME:
-                __static_getaddrinfo_canonname_mode |= (
-                    STATIC_GETADDRINFO_CANONNAME_ON_BEHAVIOR_SET
-                )
-                if canon_name:
-                    __static_getaddrinfo_canonname_mode |= (
-                        STATIC_GETADDRINFO_CANONNAME_ON_RETURN
-                    )
-            else:
-                __static_getaddrinfo_canonname_mode |= (
-                    STATIC_GETADDRINFO_CANONNAME_OFF_BEHAVIOR_SET
-                )
-                if canon_name:
-                    __static_getaddrinfo_canonname_mode |= (
-                        STATIC_GETADDRINFO_CANONNAME_OFF_RETURN
-                    )
-
-            return rv
+            return [addr]
 
         return await self._getaddrinfo(
             host, port, family, type, proto, flags, 1)


### PR DESCRIPTION
* ai_canonname is different across libc impls (#494)
* `AddressFamily` and `SocketKind` can be enums (copied from [cpython](https://github.com/python/cpython/blob/a36235d5c7863a85fa323b2048d3d254116a958e/Lib/socket.py#L100-L108))
* Also fixed failing test

Closes #494 

Per https://www.openwall.com/lists/musl/2013/03/29/13:

> it's a bug to assume a certain (libc) implementation has particular properties rather than testing.

~So the idea here is to run the libc/libuv `getaddrinfo()` first when we need to run `__static_getaddrinfo_pyaddr()` for the first time with both `AI_CANONNAME` on and off each, and remember if `ai_canonname` is set or not so that we can do the same in the future calls to `__static_getaddrinfo_pyaddr()`.~

Update: uvloop static resolving always honor the AI_CANONNAME flag, while libuv-based resolving is still consistent with the libc impl.