### PR TITLE
uvloop v0.17.0

### DIFF
--- a/uvloop/_version.py
+++ b/uvloop/_version.py
@@ -10,4 +10,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = '0.16.0'
+__version__ = '0.17.0'


### PR DESCRIPTION
This release adds Python 3.11 support, updates bundled libuv to 1.43.0
and fixes a handful of issues.

Changes
=======

* Expose uv_loop_t pointer for integration with other C-extensions (#310)
  (by @pranavtbhat in b332eb85 for #310)

* Support python 3.11+ (#473)
  (by @zeroday0619 in 8e42921d for #473)

* Expose libuv uv_fs_event functionality (#474)
  (by @jensbjorgensen @fantix in 74d381e8 for #474)

* Activate debug mode when `-X dev` is used
  (by @jack1142 in 637a77a3)

* Expose uv_version() for libuv API compatibility (#491)
  (by @fantix in 089f6cbf for #491)

* Fix loop.getaddrinfo() and tests (#495)
  (by @fantix in 598b16fd for #495)

* Bump to libuv 1.43.0
  (by @fantix in 94e5e535)

Fixes
=====

* _TransProtPair is no longer defined in asyncio.events
  (by @jensbjorgensen in fae5f7fb)

* use a TypeVar for asyncio.BaseProtocol (#478)
  (by @graingert in 3aacb352 for #478)

* Fix segfault in TimerHandle.when() after cleared
  (by @jensbjorgensen in c39afff8 for #469)

* Avoid self._errpipe_write double close (#466)
  (by @graingert in 72140d7e for #466)

* Fix typo in test (#456)
  (by @kianmeng in 033d52d0 for #456)

* Fix potential infinite loop (#446)
  (by @kfur in ada43c06 for #446)

* use a stack of self._fds_to_close to prevent double closes (#481)
  (by @graingert in 3214cf68 for #481)

* Fix incorrect main thread id value forking from a thread  (#453)
  (by @horpto @fantix in e7934c88 for #453)

* create_subprocess_exec should treat env={} as empty environment (#439) (#454)
  (by @byllyfish in e04637e0 for #439)

* Queue write only after processing all buffers (#445)
  (by @jakirkham @fantix in 9c6ecb62 for #445)

* Drop Python 3.6 support for thread ident
  (by @fantix in 9c37930e)

* bugfix: write to another transport in resume_writing() fails (#498)
  (by @fantix in d2deffef for #498)

Build
=====

* Upgrade GitHub Actions (#477) (#480)
  (by @cclauss in fcbf422d for #477, 10086942 for #480)

* typo `same as same`
  (by @YoSTEALTH in fedba80a)

* setup.py: allow to override extra_compile_args (#443)
  (by @giuliobenetti in a130375f for #443)

* Drop hack in setup.py in finalize_options (492)
  (by @fantix in 2f1bc83c for #492)

* Fix tests invocation on release CI worklow (#489)
  (by @ben9923 in d6a2b597 for #489)

Documentation
=============

* use asyncio.Runner loop_factory on 3.11+ (#472)
  (by @graingert in 31ba48ca for #472)

* Fix CI badge in docs, remove remaining Travis CI references from docs
  (by @Nothing4You in c6901a74)

* Fix typo in README
  (by @monosans in 73d7253b)