### PR TITLE
Update CI tests to use released 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11.0-rc.1"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, macos-latest]
 
     env:


### PR DESCRIPTION
Draft for:
- [ ] Fix general CI, such as the flake8 failure https://github.com/MagicStack/uvloop/actions/runs/3720859641/jobs/6310624775#step:7:570