### PR TITLE
fix github workflow badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-.. image:: https://img.shields.io/github/workflow/status/MagicStack/uvloop/Tests
-    :target: https://github.com/MagicStack/uvloop/actions?query=workflow%3ATests+branch%3Amaster
+.. image:: https://img.shields.io/github/actions/workflow/status/MagicStack/uvloop/tests.yml?branch=master
+    :target: https://github.com/MagicStack/uvloop/actions/workflows/tests.yml?query=branch%3Amaster
 
 .. image:: https://img.shields.io/pypi/v/uvloop.svg
     :target: https://pypi.python.org/pypi/uvloop

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
-.. image:: https://img.shields.io/github/workflow/status/MagicStack/uvloop/Tests
-    :target: https://github.com/MagicStack/uvloop/actions?query=workflow%3ATests+branch%3Amaster
+.. image:: https://img.shields.io/github/actions/workflow/status/MagicStack/uvloop/tests.yml?branch=master
+    :target: https://github.com/MagicStack/uvloop/actions/workflows/tests.yml?query=branch%3Amaster
 
 .. image:: https://img.shields.io/pypi/status/uvloop.svg?maxAge=2592000?style=plastic
     :target: https://pypi.python.org/pypi/uvloop


### PR DESCRIPTION
At the moment, the badges show like:

![Screenshot 2023-01-11 at 13 25 12](https://user-images.githubusercontent.com/20516159/211817587-ad97f3a6-5f85-4e2c-93d6-26e9f4a76315.png)


See the linked GitHub issue from the previous version of the badge for the root cause: https://github.com/badges/shields/issues/8671

In summary, this type of badge was changed in a breaking fashion such that the badges were just linking to the github issue rather than showing the data. Updating the url resolves this.

Also update the link of the badge to specify the workflow file rather than the name, which matches the new behaviour of the badge.

Let me know if I need to do the Sphinx build - it looks to me like this is done within ReadTheDocs but let me know if there's anything I need to do here.