### PR TITLE
Mark functions as noexcept to ensure cython 3 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from setuptools.command.build_ext import build_ext
 from setuptools.command.sdist import sdist
 
 
-CYTHON_DEPENDENCY = 'Cython(>=0.29.32,<0.30.0)'
+CYTHON_DEPENDENCY = 'Cython~=3.0.0'
 
 # Minimal dependencies required to test uvloop.
 TEST_DEPENDENCIES = [

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -916,7 +916,7 @@ class Test_UV_Process_Delayed(tb.UVTestCase):
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                __uvloop_sleep_after_fork=True))
+                _uvloop_sleep_after_fork=True))
         self.assertIsNot(transport, None)
         self.assertEqual(transport.get_returncode(), 0)
         self.assertEqual(
@@ -935,7 +935,7 @@ class Test_UV_Process_Delayed(tb.UVTestCase):
                 stdin=None,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                __uvloop_sleep_after_fork=True))
+                _uvloop_sleep_after_fork=True))
         self.assertIsNot(transport, None)
         self.assertEqual(transport.get_returncode(), 0)
         self.assertEqual(

--- a/uvloop/dns.pyx
+++ b/uvloop/dns.pyx
@@ -298,7 +298,7 @@ cdef class AddrInfo:
             uv.uv_freeaddrinfo(self.data)  # returns void
             self.data = NULL
 
-    cdef void set_data(self, system.addrinfo *data):
+    cdef void set_data(self, system.addrinfo *data) noexcept:
         self.data = data
 
     cdef unpack(self):
@@ -326,7 +326,7 @@ cdef class AddrInfo:
         return result
 
     @staticmethod
-    cdef int isinstance(object other):
+    cdef int isinstance(object other) noexcept:
         return type(other) is AddrInfo
 
 
@@ -415,7 +415,7 @@ cdef _intenum_converter(value, enum_klass):
 
 
 cdef void __on_addrinfo_resolved(uv.uv_getaddrinfo_t *resolver,
-                                 int status, system.addrinfo *res) with gil:
+                                 int status, system.addrinfo *res) noexcept with gil:
 
     if resolver.data is NULL:
         aio_logger.error(
@@ -446,7 +446,7 @@ cdef void __on_addrinfo_resolved(uv.uv_getaddrinfo_t *resolver,
 cdef void __on_nameinfo_resolved(uv.uv_getnameinfo_t* req,
                                  int status,
                                  const char* hostname,
-                                 const char* service) with gil:
+                                 const char* service) noexcept with gil:
     cdef:
         NameInfoRequest request = <NameInfoRequest> req.data
         Loop loop = request.loop

--- a/uvloop/errors.pyx
+++ b/uvloop/errors.pyx
@@ -51,7 +51,7 @@ cdef __convert_python_error(int uverr):
     return exc(oserr, __strerr(oserr))
 
 
-cdef int __convert_socket_error(int uverr):
+cdef int __convert_socket_error(int uverr) noexcept:
     cdef int sock_err = 0
 
     if uverr == uv.UV_EAI_ADDRFAMILY:

--- a/uvloop/handles/async_.pyx
+++ b/uvloop/handles/async_.pyx
@@ -41,7 +41,7 @@ cdef class UVAsync(UVHandle):
         return handle
 
 
-cdef void __uvasync_callback(uv.uv_async_t* handle) with gil:
+cdef void __uvasync_callback(uv.uv_async_t* handle) noexcept with gil:
     if __ensure_handle_data(<uv.uv_handle_t*>handle, "UVAsync callback") == 0:
         return
 

--- a/uvloop/handles/basetransport.pxd
+++ b/uvloop/handles/basetransport.pxd
@@ -47,8 +47,8 @@ cdef class UVBaseTransport(UVSocketHandle):
     # === overloads ===
 
     cdef _new_socket(self)
-    cdef size_t _get_write_buffer_size(self)
+    cdef size_t _get_write_buffer_size(self) noexcept
 
-    cdef bint _is_reading(self)
+    cdef bint _is_reading(self) noexcept
     cdef _start_reading(self)
     cdef _stop_reading(self)

--- a/uvloop/handles/basetransport.pyx
+++ b/uvloop/handles/basetransport.pyx
@@ -18,7 +18,7 @@ cdef class UVBaseTransport(UVSocketHandle):
 
         self._closing = 0
 
-    cdef size_t _get_write_buffer_size(self):
+    cdef size_t _get_write_buffer_size(self) noexcept:
         return 0
 
     cdef inline _schedule_call_connection_made(self):
@@ -211,7 +211,7 @@ cdef class UVBaseTransport(UVSocketHandle):
             self._extra_info = {}
         self._extra_info[name] = obj
 
-    cdef bint _is_reading(self):
+    cdef bint _is_reading(self) noexcept:
         raise NotImplementedError
 
     cdef _start_reading(self):

--- a/uvloop/handles/check.pyx
+++ b/uvloop/handles/check.pyx
@@ -57,7 +57,7 @@ cdef class UVCheck(UVHandle):
         return handle
 
 
-cdef void cb_check_callback(uv.uv_check_t* handle) with gil:
+cdef void cb_check_callback(uv.uv_check_t* handle) noexcept with gil:
     if __ensure_handle_data(<uv.uv_handle_t*>handle, "UVCheck callback") == 0:
         return
 

--- a/uvloop/handles/fsevent.pyx
+++ b/uvloop/handles/fsevent.pyx
@@ -90,7 +90,7 @@ cdef class UVFSEvent(UVHandle):
 
 
 cdef void __uvfsevent_callback(uv.uv_fs_event_t* handle, const char *filename,
-                               int events, int status) with gil:
+                               int events, int status) noexcept with gil:
     if __ensure_handle_data(
         <uv.uv_handle_t*>handle, "UVFSEvent callback"
     ) == 0:

--- a/uvloop/handles/handle.pyx
+++ b/uvloop/handles/handle.pyx
@@ -302,7 +302,7 @@ cdef class UVSocketHandle(UVHandle):
 
 
 cdef inline bint __ensure_handle_data(uv.uv_handle_t* handle,
-                                      const char* handle_ctx):
+                                      const char* handle_ctx) noexcept:
 
     cdef Loop loop
 
@@ -335,7 +335,7 @@ cdef inline bint __ensure_handle_data(uv.uv_handle_t* handle,
     return 1
 
 
-cdef void __uv_close_handle_cb(uv.uv_handle_t* handle) with gil:
+cdef void __uv_close_handle_cb(uv.uv_handle_t* handle) noexcept with gil:
     cdef UVHandle h
 
     if handle.data is NULL:
@@ -363,14 +363,14 @@ cdef void __uv_close_handle_cb(uv.uv_handle_t* handle) with gil:
             Py_DECREF(h)  # Was INCREFed in UVHandle._close
 
 
-cdef void __close_all_handles(Loop loop):
+cdef void __close_all_handles(Loop loop) noexcept:
     uv.uv_walk(loop.uvloop,
                __uv_walk_close_all_handles_cb,
                <void*>loop)  # void
 
 
 cdef void __uv_walk_close_all_handles_cb(
-        uv.uv_handle_t* handle, void* arg) with gil:
+        uv.uv_handle_t* handle, void* arg) noexcept with gil:
 
     cdef:
         Loop loop = <Loop>arg

--- a/uvloop/handles/idle.pyx
+++ b/uvloop/handles/idle.pyx
@@ -57,7 +57,7 @@ cdef class UVIdle(UVHandle):
         return handle
 
 
-cdef void cb_idle_callback(uv.uv_idle_t* handle) with gil:
+cdef void cb_idle_callback(uv.uv_idle_t* handle) noexcept with gil:
     if __ensure_handle_data(<uv.uv_handle_t*>handle, "UVIdle callback") == 0:
         return
 

--- a/uvloop/handles/pipe.pyx
+++ b/uvloop/handles/pipe.pyx
@@ -202,7 +202,7 @@ cdef class _PipeConnectRequest(UVRequest):
                            addr,
                            __pipe_connect_callback)
 
-cdef void __pipe_connect_callback(uv.uv_connect_t* req, int status) with gil:
+cdef void __pipe_connect_callback(uv.uv_connect_t* req, int status) noexcept with gil:
     cdef:
         _PipeConnectRequest wrapper
         UnixTransport transport

--- a/uvloop/handles/poll.pxd
+++ b/uvloop/handles/poll.pxd
@@ -10,7 +10,7 @@ cdef class UVPoll(UVHandle):
     cdef inline _poll_start(self, int flags)
     cdef inline _poll_stop(self)
 
-    cdef int is_active(self)
+    cdef int is_active(self) noexcept
 
     cdef is_reading(self)
     cdef is_writing(self)

--- a/uvloop/handles/poll.pyx
+++ b/uvloop/handles/poll.pyx
@@ -29,7 +29,7 @@ cdef class UVPoll(UVHandle):
         handle._init(loop, fd)
         return handle
 
-    cdef int is_active(self):
+    cdef int is_active(self) noexcept:
         return (self.reading_handle is not None or
                 self.writing_handle is not None)
 
@@ -191,7 +191,7 @@ cdef class UVPoll(UVHandle):
 
 
 cdef void __on_uvpoll_event(uv.uv_poll_t* handle,
-                            int status, int events) with gil:
+                            int status, int events) noexcept with gil:
 
     if __ensure_handle_data(<uv.uv_handle_t*>handle, "UVPoll callback") == 0:
         return

--- a/uvloop/handles/process.pyx
+++ b/uvloop/handles/process.pyx
@@ -732,7 +732,7 @@ cdef __process_convert_fileno(object obj):
 
 cdef void __uvprocess_on_exit_callback(uv.uv_process_t *handle,
                                        int64_t exit_status,
-                                       int term_signal) with gil:
+                                       int term_signal) noexcept with gil:
 
     if __ensure_handle_data(<uv.uv_handle_t*>handle,
                             "UVProcess exit callback") == 0:
@@ -761,5 +761,5 @@ cdef __socketpair():
     return fds[0], fds[1]
 
 
-cdef void __uv_close_process_handle_cb(uv.uv_handle_t* handle) with gil:
+cdef void __uv_close_process_handle_cb(uv.uv_handle_t* handle) noexcept with gil:
     PyMem_RawFree(handle)

--- a/uvloop/handles/stream.pyx
+++ b/uvloop/handles/stream.pyx
@@ -279,7 +279,7 @@ cdef class UVStream(UVBaseTransport):
     cdef inline _close_on_read_error(self):
         self.__read_error_close = 1
 
-    cdef bint _is_reading(self):
+    cdef bint _is_reading(self) noexcept:
         return self.__reading
 
     cdef _start_reading(self):
@@ -578,7 +578,7 @@ cdef class UVStream(UVBaseTransport):
 
         self._maybe_resume_protocol()
 
-    cdef size_t _get_write_buffer_size(self):
+    cdef size_t _get_write_buffer_size(self) noexcept:
         if self._handle is NULL:
             return 0
         return ((<uv.uv_stream_t*>self._handle).write_queue_size +
@@ -723,7 +723,7 @@ cdef class UVStream(UVBaseTransport):
 
 
 cdef void __uv_stream_on_shutdown(uv.uv_shutdown_t* req,
-                                  int status) with gil:
+                                  int status) noexcept with gil:
 
     # callback for uv_shutdown
 
@@ -752,7 +752,7 @@ cdef void __uv_stream_on_shutdown(uv.uv_shutdown_t* req,
 
 
 cdef inline bint __uv_stream_on_read_common(UVStream sc, Loop loop,
-                                            ssize_t nread):
+                                            ssize_t nread) noexcept:
     if sc._closed:
         # The stream was closed, there is no reason to
         # do any work now.
@@ -813,7 +813,7 @@ cdef inline bint __uv_stream_on_read_common(UVStream sc, Loop loop,
 
 cdef inline void __uv_stream_on_read_impl(uv.uv_stream_t* stream,
                                           ssize_t nread,
-                                          const uv.uv_buf_t* buf):
+                                          const uv.uv_buf_t* buf) noexcept:
     cdef:
         UVStream sc = <UVStream>stream.data
         Loop loop = sc._loop
@@ -841,7 +841,7 @@ cdef inline void __uv_stream_on_read_impl(uv.uv_stream_t* stream,
         sc._fatal_error(exc, False)
 
 
-cdef inline void __uv_stream_on_write_impl(uv.uv_write_t* req, int status):
+cdef inline void __uv_stream_on_write_impl(uv.uv_write_t* req, int status) noexcept:
     cdef:
         _StreamWriteContext ctx = <_StreamWriteContext> req.data
         UVStream stream = <UVStream>ctx.stream
@@ -874,7 +874,7 @@ cdef inline void __uv_stream_on_write_impl(uv.uv_write_t* req, int status):
 
 cdef void __uv_stream_on_read(uv.uv_stream_t* stream,
                               ssize_t nread,
-                              const uv.uv_buf_t* buf) with gil:
+                              const uv.uv_buf_t* buf) noexcept with gil:
 
     if __ensure_handle_data(<uv.uv_handle_t*>stream,
                             "UVStream read callback") == 0:
@@ -884,7 +884,7 @@ cdef void __uv_stream_on_read(uv.uv_stream_t* stream,
     __uv_stream_on_read_impl(stream, nread, buf)
 
 
-cdef void __uv_stream_on_write(uv.uv_write_t* req, int status) with gil:
+cdef void __uv_stream_on_write(uv.uv_write_t* req, int status) noexcept with gil:
 
     if UVLOOP_DEBUG:
         if req.data is NULL:
@@ -899,7 +899,7 @@ cdef void __uv_stream_on_write(uv.uv_write_t* req, int status) with gil:
 
 cdef void __uv_stream_buffered_alloc(uv.uv_handle_t* stream,
                                      size_t suggested_size,
-                                     uv.uv_buf_t* uvbuf) with gil:
+                                     uv.uv_buf_t* uvbuf) noexcept with gil:
 
     if __ensure_handle_data(<uv.uv_handle_t*>stream,
                             "UVStream alloc buffer callback") == 0:
@@ -947,7 +947,7 @@ cdef void __uv_stream_buffered_alloc(uv.uv_handle_t* stream,
 
 cdef void __uv_stream_buffered_on_read(uv.uv_stream_t* stream,
                                        ssize_t nread,
-                                       const uv.uv_buf_t* buf) with gil:
+                                       const uv.uv_buf_t* buf) noexcept with gil:
 
     if __ensure_handle_data(<uv.uv_handle_t*>stream,
                             "UVStream buffered read callback") == 0:

--- a/uvloop/handles/streamserver.pyx
+++ b/uvloop/handles/streamserver.pyx
@@ -122,7 +122,7 @@ cdef class UVStreamServer(UVSocketHandle):
 
 
 cdef void __uv_streamserver_on_listen(uv.uv_stream_t* handle,
-                                      int status) with gil:
+                                      int status) noexcept with gil:
 
     # callback for uv_listen
 

--- a/uvloop/handles/tcp.pyx
+++ b/uvloop/handles/tcp.pyx
@@ -204,7 +204,7 @@ cdef class _TCPConnectRequest(UVRequest):
             raise exc
 
 
-cdef void __tcp_connect_callback(uv.uv_connect_t* req, int status) with gil:
+cdef void __tcp_connect_callback(uv.uv_connect_t* req, int status) noexcept with gil:
     cdef:
         _TCPConnectRequest wrapper
         TCPTransport transport

--- a/uvloop/handles/timer.pyx
+++ b/uvloop/handles/timer.pyx
@@ -72,7 +72,7 @@ cdef class UVTimer(UVHandle):
         return handle
 
 
-cdef void __uvtimer_callback(uv.uv_timer_t* handle) with gil:
+cdef void __uvtimer_callback(uv.uv_timer_t* handle) noexcept with gil:
     if __ensure_handle_data(<uv.uv_handle_t*>handle, "UVTimer callback") == 0:
         return
 

--- a/uvloop/handles/udp.pyx
+++ b/uvloop/handles/udp.pyx
@@ -127,12 +127,12 @@ cdef class UDPTransport(UVBaseTransport):
             exc = convert_error(err)
             raise exc
 
-    cdef size_t _get_write_buffer_size(self):
+    cdef size_t _get_write_buffer_size(self) noexcept:
         if self._handle is NULL:
             return 0
         return (<uv.uv_udp_t*>self._handle).send_queue_size
 
-    cdef bint _is_reading(self):
+    cdef bint _is_reading(self) noexcept:
         return self.__receiving
 
     cdef _start_reading(self):
@@ -309,7 +309,7 @@ cdef void __uv_udp_on_receive(uv.uv_udp_t* handle,
                               ssize_t nread,
                               const uv.uv_buf_t* buf,
                               const system.sockaddr* addr,
-                              unsigned flags) with gil:
+                              unsigned flags) noexcept with gil:
 
     if __ensure_handle_data(<uv.uv_handle_t*>handle,
                             "UDPTransport receive callback") == 0:
@@ -375,7 +375,7 @@ cdef void __uv_udp_on_receive(uv.uv_udp_t* handle,
         udp._error(exc, False)
 
 
-cdef void __uv_udp_on_send(uv.uv_udp_send_t* req, int status) with gil:
+cdef void __uv_udp_on_send(uv.uv_udp_send_t* req, int status) noexcept with gil:
 
     if req.data is NULL:
         # Shouldn't happen as:

--- a/uvloop/loop.pxd
+++ b/uvloop/loop.pxd
@@ -150,7 +150,7 @@ cdef class Loop:
     cdef _call_later(self, uint64_t delay, object callback, object args,
                      object context)
 
-    cdef void _handle_exception(self, object ex)
+    cdef void _handle_exception(self, object ex) noexcept
 
     cdef inline _is_main_thread(self)
 

--- a/uvloop/loop.pyx
+++ b/uvloop/loop.pyx
@@ -2750,7 +2750,7 @@ cdef class Loop:
                                executable=None,
                                pass_fds=(),
                                # For tests only! Do not use in your code. Ever.
-                               __uvloop_sleep_after_fork=False):
+                               _uvloop_sleep_after_fork=False):
 
         # TODO: Implement close_fds (might not be very important in
         # Python 3.5, since all FDs aren't inheritable by default.)
@@ -2770,7 +2770,7 @@ cdef class Loop:
         if executable is not None:
             args[0] = executable
 
-        if __uvloop_sleep_after_fork:
+        if _uvloop_sleep_after_fork:
             debug_flags |= __PROCESS_DEBUG_SLEEP_AFTER_FORK
 
         waiter = self._new_future()

--- a/uvloop/loop.pyx
+++ b/uvloop/loop.pyx
@@ -681,7 +681,7 @@ cdef class Loop:
                      object context):
         return TimerHandle(self, callback, args, delay, context)
 
-    cdef void _handle_exception(self, object ex):
+    cdef void _handle_exception(self, object ex) noexcept:
         if isinstance(ex, Exception):
             self.call_exception_handler({'exception': ex})
         else:
@@ -3232,7 +3232,7 @@ def libuv_get_version():
 
 cdef void __loop_alloc_buffer(uv.uv_handle_t* uvhandle,
                               size_t suggested_size,
-                              uv.uv_buf_t* buf) with gil:
+                              uv.uv_buf_t* buf) noexcept with gil:
     cdef:
         Loop loop = (<UVHandle>uvhandle.data)._loop
 
@@ -3330,7 +3330,7 @@ cdef vint __forking = 0
 cdef Loop __forking_loop = None
 
 
-cdef void __get_fork_handler() nogil:
+cdef void __get_fork_handler() noexcept nogil:
     with gil:
         if (__forking and __forking_loop is not None and
                 __forking_loop.active_process_handler is not None):

--- a/uvloop/sslproto.pxd
+++ b/uvloop/sslproto.pxd
@@ -122,7 +122,7 @@ cdef class SSLProtocol:
     # Flow control for writes from APP socket
 
     cdef _control_app_writing(self, object context=*)
-    cdef size_t _get_write_buffer_size(self)
+    cdef size_t _get_write_buffer_size(self) noexcept
     cdef _set_write_buffer_limits(self, high=*, low=*)
 
     # Flow control for reads to APP socket
@@ -134,5 +134,5 @@ cdef class SSLProtocol:
 
     cdef _control_ssl_reading(self)
     cdef _set_read_buffer_limits(self, high=*, low=*)
-    cdef size_t _get_read_buffer_size(self)
+    cdef size_t _get_read_buffer_size(self) noexcept
     cdef _fatal_error(self, exc, message=*)

--- a/uvloop/sslproto.pyx
+++ b/uvloop/sslproto.pyx
@@ -861,7 +861,7 @@ cdef class SSLProtocol:
                     'protocol': self,
                 })
 
-    cdef size_t _get_write_buffer_size(self):
+    cdef size_t _get_write_buffer_size(self) noexcept:
         return self._outgoing.pending + self._write_buffer_size
 
     cdef _set_write_buffer_limits(self, high=None, low=None):
@@ -903,7 +903,7 @@ cdef class SSLProtocol:
         self._incoming_high_water = high
         self._incoming_low_water = low
 
-    cdef size_t _get_read_buffer_size(self):
+    cdef size_t _get_read_buffer_size(self) noexcept:
         return self._incoming.pending
 
     # Flow control for writes to SSL socket


### PR DESCRIPTION
Cython 3 will require `noexcept` keyword for functions not raising an exception: https://cython.readthedocs.io/en/latest/src/userguide/migrating_to_cy30.html#exception-values-and-noexcept
Cython 0.29.32 introduces this keyword too for forward compatibility. This PR fixes multiple issues found in https://github.com/cython/cython/issues/5305.

> **Note**: Currently uvloop cannot be compiled in cython 3.0.0b1 because of issue https://github.com/cython/cython/issues/5270. In the next Cython release the issue should be fixed.
