### PR TITLE
CI: python 3.11 stable

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11.0-rc.1"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, macos-latest]
 
     env:

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,7 @@ TEST_DEPENDENCIES = [
     # pycodestyle is a dependency of flake8, but it must be frozen because
     # their combination breaks too often
     # (example breakage: https://gitlab.com/pycqa/flake8/issues/427)
-    # aiohttp doesn't support 3.11 yet,
-    # see https://github.com/aio-libs/aiohttp/issues/6600
-    'aiohttp ; python_version < "3.11"',
+    'aiohttp>=3.8.1',
     'flake8~=5.0',
     'psutil',
     'pycodestyle~=2.9.0',


### PR DESCRIPTION
Let's use stable version of Python 3.11. Once merged I'll try to add Python 3.12 to the CI which was failing at first attempt.