### PR TITLE
CI: python 3.12-dev

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
         os: [ubuntu-latest, macos-latest]
 
     env:

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ TEST_DEPENDENCIES = [
     # pycodestyle is a dependency of flake8, but it must be frozen because
     # their combination breaks too often
     # (example breakage: https://gitlab.com/pycqa/flake8/issues/427)
-    'aiohttp>=3.8.1',
+    'aiohttp>=3.8.1 ; python_version < "3.12"',
     'flake8~=5.0',
     'psutil',
     'pycodestyle~=2.9.0',

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from setuptools.command.build_ext import build_ext
 from setuptools.command.sdist import sdist
 
 
-CYTHON_DEPENDENCY = 'Cython(>=0.29.32,<0.30.0)'
+CYTHON_DEPENDENCY = 'Cython(>=0.29.35,<0.30.0)'
 
 # Minimal dependencies required to test uvloop.
 TEST_DEPENDENCIES = [


### PR DESCRIPTION
This PR is blocked because _imp_ module used by Cython is removed in Python 3.12, thus causing import errors. Cython switched to _importlib_ in version 3.0.