### PR TITLE
Make extract_stack resilient to lacking frames.

### DIFF
--- a/uvloop/cbhandles.pyx
+++ b/uvloop/cbhandles.pyx
@@ -414,7 +414,12 @@ cdef extract_stack():
     """Replacement for traceback.extract_stack() that only does the
     necessary work for asyncio debug mode.
     """
-    f = sys_getframe()
+    try:
+        f = sys_getframe()
+    # sys._getframe() might raise ValueError if being called without a frame, e.g.
+    # from Cython or similar C extensions.
+    except ValueError:
+        return None
     if f is None:
         return
 


### PR DESCRIPTION
We are using uvloop in conjunction with an implementation of GRPC (not the default one) that is using C++ and Cython instead of native code. This means we try to do things with the loop while not holding a frame, which causes crashes when we enable debug mode on the loop. From reading Cython documentation this seems kinda impossible to adjust to have a frame. But it is fairly easy to just not fail hard here.