### PR TITLE
uvloop 0.18.0

### DIFF
--- a/uvloop/_version.py
+++ b/uvloop/_version.py
@@ -10,4 +10,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = '0.17.0'
+__version__ = '0.18.0'


### PR DESCRIPTION
Changes
=======

* Port uvloop to Python 3.12 (#570)
  (by @1st1, @fantix in 9f82bd74 for #569)

* Upgrade libuv to v1.46.0 (#571)
  (by @fantix in 2e1978c3 for #571)

Fixes
=====

* CI fixes (#520, #553)
  (by @altendky in 7783f1c5, @dulmandakh in 1dd40f17)

* Make extract_stack resilient to lacking frames. (#563)
  (by @jhance in 06876434 for #563)