### PR TITLE
uvloop 0.19.0

### DIFF
--- a/uvloop/_version.py
+++ b/uvloop/_version.py
@@ -10,4 +10,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = '0.18.0'
+__version__ = '0.19.0'


### PR DESCRIPTION
Changes
=======

* Drop support of Python 3.7 and update CI (#578)
  (by @fantix in ee5ad26a for #578)

Fixes
=====

* Restore uvloop.new_event_loop and other missing uvloop members to typing (#573)
  (by @graingert in 5c500ee2 for #573)

* Fix docstring of loop.shutdown_default_executor (#535)
  (by @Gelbpunkt in 919da567 for #535)

* Fix CI status badge (#522)
  (by @shuuji3 in 0e9ff6cd for #522)