### PR TITLE
Update loop task factory typing with kwargs

### DIFF
--- a/uvloop/loop.pyi
+++ b/uvloop/loop.pyi
@@ -11,6 +11,7 @@ from typing import (
     Generator,
     List,
     Optional,
+    Protocol,
     Sequence,
     Tuple,
     TypeVar,
@@ -23,6 +24,14 @@ _Context = Dict[str, Any]
 _ExceptionHandler = Callable[[asyncio.AbstractEventLoop, _Context], Any]
 _SSLContext = Union[bool, None, ssl.SSLContext]
 _ProtocolT = TypeVar("_ProtocolT", bound=asyncio.BaseProtocol)
+
+
+class TaskFactoryCallable(Protocol):
+    def __call__(
+        self, loop: asyncio.AbstractEventLoop, coro: Generator[Any, None, _T], **kwargs: Any
+    ) -> asyncio.Future[_T]:
+        ...
+
 
 class Loop:
     def call_soon(
@@ -52,17 +61,8 @@ class Loop:
         *,
         name: Optional[str] = ...,
     ) -> asyncio.Task[_T]: ...
-    def set_task_factory(
-        self,
-        factory: Optional[
-            Callable[[asyncio.AbstractEventLoop, Generator[Any, None, _T]], asyncio.Future[_T]]
-        ],
-    ) -> None: ...
-    def get_task_factory(
-        self,
-    ) -> Optional[
-        Callable[[asyncio.AbstractEventLoop, Generator[Any, None, _T]], asyncio.Future[_T]]
-    ]: ...
+    def set_task_factory(self, factory: Optional[TaskFactoryCallable]) -> None: ...
+    def get_task_factory(self) -> Optional[TaskFactoryCallable]: ...
     @overload
     def run_until_complete(self, future: Generator[Any, None, _T]) -> _T: ...
     @overload


### PR DESCRIPTION
Issue: https://github.com/MagicStack/uvloop/issues/584

For `PY311` the task factory will be called with the context kwarg. This is not correctly reflected in the typing for `Loop.set_task_factory` and `Loop.get_task_factory`. 

This commit addresses this with a protocol. Since `uvloop` requires a minimum Python 3.8 version, in which [`typing.Protocol` is available](https://docs.python.org/3.8/library/typing.html#typing.Protocol). Note, neither  [`typing.Unpack` for kwargs, (introduced in Python 3.11)](https://docs.python.org/3/library/typing.html#typing.Unpack) or [`typing.ParmSpec` with `ParamSpec.kwargs` (introduced in Python 3.10)](https://docs.python.org/3.10/library/typing.html#typing.ParamSpec) is available for 3.8

Did not explicitly type the `context` parameter and used `**kwargs` since the Loop method allows for the [legacy API without a context param](https://github.com/MagicStack/uvloop/blob/master/uvloop/loop.pyx#L1437) for `<PY311`

Also see discussion about `name` parameter for task factory in asyncio: https://github.com/python/cpython/pull/112623#issuecomment-1837405443

Quick demonstration of typing (see [mypy Callback Protocols](https://mypy.readthedocs.io/en/stable/protocols.html#callback-protocols))
``` py
# test.py
import asyncio
from typing import Any, Generator, Protocol, TypeVar

_T = TypeVar("_T")


class TaskFactoryCallable(Protocol):
    def __call__(
        self, loop: asyncio.AbstractEventLoop, coro: Generator[Any, None, _T], **kwargs
    ) -> asyncio.Future[_T]:
        ...


def set_task_factory(factory: TaskFactoryCallable) -> None:
    ...


def task_factory_valid(
    loop: asyncio.AbstractEventLoop, coro: Generator[Any, None, _T], **kwargs
) -> asyncio.Future[_T]:
    return asyncio.Future()


def task_factory_invalid(
    loop: asyncio.AbstractEventLoop, coro: Generator[Any, None, _T]
) -> asyncio.Future[_T]:
    return asyncio.Future()


# Passes mypy
set_task_factory(task_factory_valid)

# Fails mypy
set_task_factory(task_factory_invalid)
```

```bash
mypy test.py 
# test.py:35: error: Argument 1 to "set_task_factory" has incompatible type "Callable[[AbstractEventLoop, Generator[Any, None, _T]], Future[_T]]"; expected "TaskFactoryCallable"  [arg-type]
# Found 1 error in 1 file (checked 1 source file)
```
