### PR TITLE
fix Future exception never retrieved in create_connection

### DIFF
--- a/uvloop/loop.pyx
+++ b/uvloop/loop.pyx
@@ -1972,7 +1972,12 @@ cdef class Loop:
                     lai = &lai_static
 
             if len(fs):
-                await aio_wait(fs)
+                try:
+                    await aio_wait(fs)
+                except asyncio.CancelledError as exc:
+                    for fut in fs:
+                        fut.cancel()
+                    raise exc from None
 
             if rai is NULL:
                 ai_remote = f1.result()


### PR DESCRIPTION
I also have observed that when I use asyncio.wait_for(...) around loop.create_connection in the timeout case I end up getting this logged to stdout(err?):

Future exception was never retrieved
future: <Future finished exception=gaierror(-2, 'Name or service not known')>
socket.gaierror: [Errno -2] Name or service not known

The code in this commit fixes this.
