### PR TITLE
Use len(os.sched_getaffinity(0)) instead of os.cpu_count()

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest, macos-latest]

--- a/setup.py
+++ b/setup.py
@@ -176,7 +176,7 @@ class uvloop_build_ext(build_ext):
             cmd,
             cwd=LIBUV_BUILD_DIR, env=env, check=True)
 
-        j_flag = '-j{}'.format(os.cpu_count() or 1)
+        j_flag = '-j{}'.format(len(os.sched_getaffinity(0)) or 1)
         c_flag = "CFLAGS={}".format(env['CFLAGS'])
         subprocess.run(
             ['make', j_flag, c_flag],

--- a/setup.py
+++ b/setup.py
@@ -176,7 +176,11 @@ class uvloop_build_ext(build_ext):
             cmd,
             cwd=LIBUV_BUILD_DIR, env=env, check=True)
 
-        j_flag = '-j{}'.format(len(os.sched_getaffinity(0)) or 1)
+        try:
+            njobs = len(os.sched_getaffinity(0))
+        except AttributeError:
+            njobs = os.cpu_count()
+        j_flag = '-j{}'.format(njobs or 1)
         c_flag = "CFLAGS={}".format(env['CFLAGS'])
         subprocess.run(
             ['make', j_flag, c_flag],


### PR DESCRIPTION
This change allows to control number of processes by cpuset command.