### PR TITLE
Add support for special hostname <broadcast>

### DIFF
--- a/tests/test_udp.py
+++ b/tests/test_udp.py
@@ -378,6 +378,22 @@ class Test_UV_UDP(_TestUDP, tb.UVTestCase):
         s_transport.close()
         self.loop.run_until_complete(asyncio.sleep(0.01))
 
+    def test_udp_sendto_broadcast(self):
+        coro = self.loop.create_datagram_endpoint(
+            asyncio.DatagramProtocol,
+            local_addr=('127.0.0.1', 0),
+            family=socket.AF_INET)
+
+        s_transport, server = self.loop.run_until_complete(coro)
+
+        try:
+            s_transport.sendto(b'aaaa', ('<broadcast>', 80))
+        except ValueError as exc:
+            raise AssertionError('sendto raises {}.'.format(exc))
+
+        s_transport.close()
+        self.loop.run_until_complete(asyncio.sleep(0.01))
+
     def test_send_after_close(self):
         coro = self.loop.create_datagram_endpoint(
             asyncio.DatagramProtocol,

--- a/uvloop/dns.pyx
+++ b/uvloop/dns.pyx
@@ -113,6 +113,10 @@ cdef __convert_pyaddr_to_sockaddr(int family, object addr,
 
         port = __port_to_int(port, None)
 
+        # resolve special hostname <broadcast> to the broadcast address
+        if host == b'<broadcast>':
+            host = b'255.255.255.255'
+
         ret.addr_size = sizeof(system.sockaddr_in)
         err = uv.uv_ip4_addr(host, <int>port, <system.sockaddr_in*>&ret.addr)
         if err < 0:


### PR DESCRIPTION
Currently `sendto` would fail if you use the special hostname `<broadcast>`, which is a valid use according to the [Python docs](https://docs.python.org/3/library/socket.html#socket-families:~:text=For%20IPv4%20addresses%2C%20two%20special%20forms). This PR proposes to to "resolve" it to the broadcast address before passing it to `uv_ip4_addr`.

This resolves the issue https://github.com/MagicStack/uvloop/issues/540