### PR TITLE
udp errors should result in protocol.error_received, inconsistent with vanilla asyncio

### DIFF
--- a/uvloop/handles/udp.pyx
+++ b/uvloop/handles/udp.pyx
@@ -244,14 +244,20 @@ cdef class UDPTransport(UVBaseTransport):
                 ctx.close()
 
                 exc = convert_error(err)
-                self._fatal_error(exc, True)
+                if isinstance(exc, OSError):
+                    self._protocol.error_received(exc)
+                else:
+                    self._fatal_error(exc, True)
             else:
                 self._maybe_pause_protocol()
 
         else:
             if err < 0:
                 exc = convert_error(err)
-                self._fatal_error(exc, True)
+                if isinstance(exc, OSError):
+                    self._protocol.error_received(exc)
+                else:
+                    self._fatal_error(exc, True)
             else:
                 self._on_sent(None, self.context.copy())
 

--- a/uvloop/handles/udp.pyx
+++ b/uvloop/handles/udp.pyx
@@ -245,21 +245,14 @@ cdef class UDPTransport(UVBaseTransport):
 
                 exc = convert_error(err)
                 if isinstance(exc, OSError):
-                    self._protocol.error_received(exc)
+                    run_in_context1(self.context.copy(), self._protocol.error_received, exc)
                 else:
                     self._fatal_error(exc, True)
             else:
                 self._maybe_pause_protocol()
 
         else:
-            if err < 0:
-                exc = convert_error(err)
-                if isinstance(exc, OSError):
-                    self._protocol.error_received(exc)
-                else:
-                    self._fatal_error(exc, True)
-            else:
-                self._on_sent(None, self.context.copy())
+            self._on_sent(convert_error(err) if err < 0 else None, self.context.copy())
 
     cdef _on_receive(self, bytes data, object exc, object addr):
         if exc is None:


### PR DESCRIPTION
I observed a condition in production where a temporary network outage caused a UDP sendto to fail. In stock asyncio this would result in a call to error_received on the protocol object, but in uvloop this results in a fatal error that closes the transport. This is a rather nasty thing to happen since with vanilla asyncio when the transient network condition was resolved the transport could again be used, but with uvloop you would have to close the transport and repoen it.. See cpython source here:

https://github.com/python/cpython/blob/main/Lib/asyncio/selector_events.py#L1240

Sorry I don't have a script/fragment to reproduce the error, to do this you'd have to manipulate the networking stack such that the interface was not available after the transport was created. It's possible of course but I don't know of an easy way to do this.