### PR TITLE
Inline _Py_RestoreSignals() from CPython

### DIFF
--- a/uvloop/includes/compat.h
+++ b/uvloop/includes/compat.h
@@ -1,5 +1,6 @@
 #include <errno.h>
 #include <stddef.h>
+#include <signal.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include "Python.h"
@@ -83,3 +84,22 @@ int Context_Exit(PyObject *ctx) {
 }
 
 #endif
+
+/* inlined from cpython/Modules/signalmodule.c
+ * https://github.com/python/cpython/blob/v3.13.0a6/Modules/signalmodule.c#L1931-L1951
+ * private _Py_RestoreSignals has been moved to CPython internals in Python 3.13
+ * https://github.com/python/cpython/pull/106400 */
+
+void
+_Py_RestoreSignals(void)
+{
+#ifdef SIGPIPE
+    PyOS_setsig(SIGPIPE, SIG_DFL);
+#endif
+#ifdef SIGXFZ
+    PyOS_setsig(SIGXFZ, SIG_DFL);
+#endif
+#ifdef SIGXFSZ
+    PyOS_setsig(SIGXFSZ, SIG_DFL);
+#endif
+}

--- a/uvloop/includes/python.pxd
+++ b/uvloop/includes/python.pxd
@@ -11,8 +11,6 @@ cdef extern from "Python.h":
     object PyUnicode_EncodeFSDefault(object)
     void PyErr_SetInterrupt() nogil
 
-    void _Py_RestoreSignals()
-
     object PyMemoryView_FromMemory(char *mem, ssize_t size, int flags)
     object PyMemoryView_FromObject(object obj)
     int PyMemoryView_Check(object obj)
@@ -29,3 +27,5 @@ cdef extern from "includes/compat.h":
     void PyOS_BeforeFork()
     void PyOS_AfterFork_Parent()
     void PyOS_AfterFork_Child()
+
+    void _Py_RestoreSignals()


### PR DESCRIPTION
private _Py_RestoreSignals() has been moved to CPython internals as of Python 3.13 See: https://github.com/python/cpython/pull/106400 Its implementation has been the same in all supported by uvloop Pythons (3.8+), so the inlining was not conditionalized.

Closes #603 

This allows to build uvloop with Python 3.13.0a6.

Unfortunately, one of the tests fails and I can't tell whether it's related to this or it's an incidental breakage coming from some other parts of CPython changes:

```
=================================== FAILURES ===================================
___________________ Test_AIO_Unix.test_create_unix_server_1 ____________________
Traceback (most recent call last):
  File "/usr/lib64/python3.13/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/usr/lib64/python3.13/unittest/case.py", line 651, in run
    self._callTestMethod(testMethod)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/usr/lib64/python3.13/unittest/case.py", line 606, in _callTestMethod
    if method() is not None:
       ~~~~~~^^
  File "/builddir/build/BUILD/uvloop-0.19.0/_empty/tests/test_unix.py", line 147, in test_create_unix_server_1
    self.loop.run_until_complete(start_server())
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.13/asyncio/base_events.py", line 721, in run_until_complete
    return future.result()
           ~~~~~~~~~~~~~^^
  File "/builddir/build/BUILD/uvloop-0.19.0/_empty/tests/test_unix.py", line 100, in start_server
    self.assertTrue(os.path.exists(sock_name))
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.13/unittest/case.py", line 744, in assertTrue
    raise self.failureException(msg)
AssertionError: False is not true
```