### PR TITLE
Redirect windows users trying to install to uvloop to winloop for the time being

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ if vi < (3, 8):
     raise RuntimeError('uvloop requires Python 3.8 or greater')
 
 if sys.platform in ('win32', 'cygwin', 'cli'):
-    raise RuntimeError('uvloop does not support Windows at the moment')
+    raise RuntimeError('uvloop does not support Windows at the moment, try installing winloop instead')
 
 import os
 import os.path


### PR DESCRIPTION
About a year ago I was wanting to make uvloop on windows a reality in the hopes to get rid of window's crappy asyncio performance which I named [winloop](https://github.com/vizonex/winloop) and as the main developer of that library and since the library has been slowly maturing I was wondering if you guys would be willing to accept this pull request for the time being to let users know that there's a readily available alternative for using uvloop on windows.  I have some other contributors that have been working very hard on my end to see if we can merge our library with yours when in the future. The only thing that concerns me with this future merge is cython's recent deprecation of macros, other than that I am very excited to contribute to this amazing work.