### PR TITLE
Use cythonized SO_REUSEPORT rather than the unwrapped native one.

### DIFF
--- a/uvloop/includes/uv.pxd
+++ b/uvloop/includes/uv.pxd
@@ -57,7 +57,7 @@ cdef extern from "uv.h" nogil:
     cdef int SOL_SOCKET
     cdef int SO_ERROR
     cdef int SO_REUSEADDR
-    cdef int SO_REUSEPORT
+    # use has_SO_REUSEPORT and SO_REUSEPORT in stdlib.pxi instead
     cdef int AF_INET
     cdef int AF_INET6
     cdef int AF_UNIX

--- a/uvloop/loop.pyx
+++ b/uvloop/loop.pyx
@@ -1775,7 +1775,7 @@ cdef class Loop:
                         if reuse_address:
                             sock.setsockopt(uv.SOL_SOCKET, uv.SO_REUSEADDR, 1)
                         if reuse_port:
-                            sock.setsockopt(uv.SOL_SOCKET, uv.SO_REUSEPORT, 1)
+                            sock.setsockopt(uv.SOL_SOCKET, SO_REUSEPORT, 1)
                         # Disable IPv4/IPv6 dual stack support (enabled by
                         # default on Linux) which makes a single socket
                         # listen on both address families.


### PR DESCRIPTION
The code already detects (via hasattr) whether SO_REUSEPORT is available, setting has_SO_REUSEPORT, and creates a wrapped SO_REUSEPORT (via getattr). This change ensures it's that wrapped SO_REUSEPORT that's used, rather than the native C version (which may not exist).

Fixes #550