### PR TITLE
Fix test_create_server_4 with Python 3.12.5

### DIFF
--- a/tests/test_tcp.py
+++ b/tests/test_tcp.py
@@ -249,7 +249,8 @@ class _TestTCP:
 
             with self.assertRaisesRegex(OSError,
                                         r"error while attempting.*\('127.*:"
-                                        r"( \[errno \d+\])? address( already)? in use"):
+                                        r"( \[errno \d+\])? address"
+                                        r"( already)? in use"):
 
                 self.loop.run_until_complete(
                     self.loop.create_server(object, *addr))

--- a/tests/test_tcp.py
+++ b/tests/test_tcp.py
@@ -248,8 +248,8 @@ class _TestTCP:
             addr = sock.getsockname()
 
             with self.assertRaisesRegex(OSError,
-                                        r"error while attempting.*\('127.*: "
-                                        r"address( already)? in use"):
+                                        r"error while attempting.*\('127.*:"
+                                        r"( \[errno \d+\])? address( already)? in use"):
 
                 self.loop.run_until_complete(
                     self.loop.create_server(object, *addr))


### PR DESCRIPTION
After https://github.com/python/cpython/issues/121913 error message `[errno 98] address already in use`