### PR TITLE
uvloop 0.20.0

### DIFF
--- a/uvloop/_version.py
+++ b/uvloop/_version.py
@@ -10,4 +10,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = '0.19.0'
+__version__ = '0.20.0'


### PR DESCRIPTION
Changes
=======

* Upgrade libuv to v1.48.0 (#600)
  (by @niklasr22 @fantix in 77778525 for #596 #615)

Fixes
=====

* Fix test_create_server_4 with Python 3.12.5 (#614)
  (by @shadchin in 62f92393)

* Use len(os.sched_getaffinity(0)) instead of os.cpu_count() (#591)
  (by @avkarenow in c8531c24 for #591)

* Inline _Py_RestoreSignals() from CPython (#604)
  (by @befeleme in 8511ba1f for #603)