### PR TITLE
Improve performance and reduce latency of Transport.write by attempting to send data immediately if all write buffers are empty

### DIFF
--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -512,9 +512,10 @@ class _ContextBaseTests(tb.SSLTestCase):
                         proto.transport.write(b'q' * 16384)
                         count += 1
                 else:
-                    proto.transport.write(b'q' * 16384)
                     proto.transport.set_write_buffer_limits(high=256, low=128)
-                    count += 1
+                    while not proto.transport.get_write_buffer_size():
+                        proto.transport.write(b'q' * 16384)
+                        count += 1
                 return count
 
             s = self.loop.run_in_executor(None, accept)

--- a/tests/test_tcp.py
+++ b/tests/test_tcp.py
@@ -1224,21 +1224,16 @@ class Test_UV_TCP(_TestTCP, tb.UVTestCase):
             t, p = await self.loop.create_connection(Protocol, *addr)
 
             t.write(b'q' * 512)
-            self.assertEqual(t.get_write_buffer_size(), 512)
-
             t.set_write_buffer_limits(low=16385)
-            self.assertFalse(paused)
             self.assertEqual(t.get_write_buffer_limits(), (16385, 65540))
 
             with self.assertRaisesRegex(ValueError, 'high.*must be >= low'):
                 t.set_write_buffer_limits(high=0, low=1)
 
             t.set_write_buffer_limits(high=1024, low=128)
-            self.assertFalse(paused)
             self.assertEqual(t.get_write_buffer_limits(), (128, 1024))
 
             t.set_write_buffer_limits(high=256, low=128)
-            self.assertTrue(paused)
             self.assertEqual(t.get_write_buffer_limits(), (128, 256))
 
             t.close()

--- a/uvloop/handles/stream.pxd
+++ b/uvloop/handles/stream.pxd
@@ -35,7 +35,7 @@ cdef class UVStream(UVBaseTransport):
     # and then call _initiate_write() to start writing either immediately or in
     # the next iteration (loop._queue_write()).
     cdef inline _buffer_write(self, object data)
-    cdef inline _initiate_write(self)
+    cdef inline _initiate_write(self, bint skip_fast_path)
 
     # _exec_write() is the method that does the actual send, and _try_write()
     # is a fast-path used in _exec_write() to send a single chunk.

--- a/uvloop/handles/stream.pyx
+++ b/uvloop/handles/stream.pyx
@@ -701,7 +701,7 @@ cdef class UVStream(UVBaseTransport):
             bytes_written = bytes_written_
 
             if bytes_written == 0:
-                # All data was successfully bytes_written.
+                # All data was successfully written.
                 # on_write will call "maybe_resume_protocol".
                 return
 

--- a/uvloop/handles/stream.pyx
+++ b/uvloop/handles/stream.pyx
@@ -424,11 +424,13 @@ cdef class UVStream(UVBaseTransport):
         self._buffer_size += dlen
         self._buffer.append(data)
 
-    cdef inline _initiate_write(self):
-        if (not self._protocol_paused and
-                (<uv.uv_stream_t*>self._handle).write_queue_size == 0 and
-                self._buffer_size > self._high_water):
+    cdef inline _initiate_write(self, bint skip_fast_path):
+        if (not skip_fast_path and
+            not self._protocol_paused and
+            (<uv.uv_stream_t*>self._handle).write_queue_size == 0 and
+            self._buffer_size > self._high_water):
             # Fast-path.  If:
+            #   - the caller hasn't tried fast path itself
             #   - the protocol isn't yet paused,
             #   - there is no data in libuv buffers for this stream,
             #   - the protocol will be paused if we continue to buffer data
@@ -687,9 +689,7 @@ cdef class UVStream(UVBaseTransport):
 
         cdef ssize_t bytes_written
 
-        if (not self._protocol_paused and self._buffer_size == 0 and
-            (<uv.uv_stream_t*>self._handle).write_queue_size == 0):
-
+        if self._get_write_buffer_size() == 0:
             bytes_written_ = self._try_write(buf)
 
             if bytes_written_ is None:
@@ -726,7 +726,7 @@ cdef class UVStream(UVBaseTransport):
             # buffer remaining data and send it later
 
         self._buffer_write(buf)
-        self._initiate_write()
+        self._initiate_write(True)  # skip fast path in _initiate_write
 
     def writelines(self, bufs):
         self._ensure_alive()
@@ -738,7 +738,7 @@ cdef class UVStream(UVBaseTransport):
             return
         for buf in bufs:
             self._buffer_write(buf)
-        self._initiate_write()
+        self._initiate_write(False) # try fast path in _initiate_write
 
     def write_eof(self):
         self._ensure_alive()

--- a/uvloop/handles/stream.pyx
+++ b/uvloop/handles/stream.pyx
@@ -681,14 +681,14 @@ cdef class UVStream(UVBaseTransport):
             self._conn_lost += 1
             return
 
-        cdef ssize_t written
+        cdef ssize_t bytes_written
 
         if (not self._protocol_paused and self._buffer_size == 0 and
             (<uv.uv_stream_t*>self._handle).write_queue_size == 0):
 
-            written_ = self._try_write(buf)
+            bytes_written_ = self._try_write(buf)
 
-            if written_ is None:
+            if bytes_written_ is None:
                 # A `self._fatal_error` was called.
                 # It might not raise an exception under some
                 # conditions.
@@ -698,16 +698,16 @@ cdef class UVStream(UVBaseTransport):
 
                 return
 
-            written = written_
+            bytes_written = bytes_written_
 
-            if written == 0:
-                # All data was successfully written.
+            if bytes_written == 0:
+                # All data was successfully bytes_written.
                 # on_write will call "maybe_resume_protocol".
                 return
 
-            if written > 0:
+            if bytes_written > 0:
                 if UVLOOP_DEBUG:
-                    if written == len(buf):
+                    if bytes_written == len(buf):
                         raise RuntimeError('_try_write sent all data and '
                                            'returned non-zero')
 
@@ -715,7 +715,7 @@ cdef class UVStream(UVBaseTransport):
                     # Cast bytes to memoryview to avoid copying
                     # data that wasn't sent.
                     buf = memoryview(buf)
-                buf = buf[written_:]
+                buf = buf[bytes_written_:]
 
             # At this point it's either data was sent partially,
             # or an EAGAIN has happened.

--- a/uvloop/handles/stream.pyx
+++ b/uvloop/handles/stream.pyx
@@ -375,7 +375,6 @@ cdef class UVStream(UVBaseTransport):
         # uv_try_write -- less layers of code.  The error
         # checking logic is copied from libuv.
         written = system.write(fd, buf, blen)
-
         while written == -1 and (
                 errno.errno == errno.EINTR or
                 (system.PLATFORM_IS_APPLE and


### PR DESCRIPTION
Current implementation of UVStream.write almost never sends data immediately. Instead the data is stored in the buffer and picked up later by uv_check callback.
This introduces unnecessary latency and CPU overhead

This PR increases RPS rate between echoclient and echoserver by roughly 10%.
`echoclient --worker 1 --num 200000`
`echoserver --uvloop --proto `

Because  of this change a couple of test had to be tweaked.
* get_write_buffer_size cannot reliably return how much data has been already buffered. It doesn't take into account the socket send buffer (which is in the kernel)
* writing above limits does not necessarily cause pause_writing because again the data first goes to the socket send buffer

Please note that the current implementation of asyncio does the same thing. It tries to write directly to the socket, and, only if EWOULDBLOCK happens, the data is added to the buffer
https://github.com/python/cpython/blob/c13e7d98fb8581014a225b900b1b88ccbfc28097/Lib/asyncio/selector_events.py#L1065