### PR TITLE
Add cleanup_socket param on create_unix_server()

### DIFF
--- a/uvloop/handles/pipe.pyx
+++ b/uvloop/handles/pipe.pyx
@@ -80,6 +80,27 @@ cdef class UnixServer(UVStreamServer):
                                context)
         return <UVStream>tr
 
+    cdef _close(self):
+        sock = self._fileobj
+        if sock is not None and sock in self._loop._unix_server_sockets:
+            path = sock.getsockname()
+        else:
+            path = None
+
+        UVStreamServer._close(self)
+
+        if path is not None:
+            prev_ino = self._loop._unix_server_sockets[sock]
+            del self._loop._unix_server_sockets[sock]
+            try:
+                if os_stat(path).st_ino == prev_ino:
+                    os_unlink(path)
+            except FileNotFoundError:
+                pass
+            except OSError as err:
+                aio_logger.error('Unable to clean up listening UNIX socket '
+                                 '%r: %r', path, err)
+
 
 @cython.no_gc_clear
 cdef class UnixTransport(UVStream):

--- a/uvloop/includes/stdlib.pxi
+++ b/uvloop/includes/stdlib.pxi
@@ -112,6 +112,7 @@ cdef os_pipe = os.pipe
 cdef os_read = os.read
 cdef os_remove = os.remove
 cdef os_stat = os.stat
+cdef os_unlink = os.unlink
 cdef os_fspath = os.fspath
 
 cdef stat_S_ISSOCK = stat.S_ISSOCK

--- a/uvloop/loop.pxd
+++ b/uvloop/loop.pxd
@@ -58,6 +58,7 @@ cdef class Loop:
         set _processes
         dict _fd_to_reader_fileobj
         dict _fd_to_writer_fileobj
+        dict _unix_server_sockets
 
         set _signals
         dict _signal_handlers


### PR DESCRIPTION
This is derived from python/cpython#111483 but available on all Python versions with uvloop, only that it's only enabled by default for Python 3.13 and above to be consistent with CPython behavior.

[Sample CI run on 3.13](https://github.com/MagicStack/uvloop/actions/runs/10602346530/job/29384175737?pr=610)