### PR TITLE
Optimizations for SSLProtocol

### DIFF
--- a/uvloop/sslproto.pxd
+++ b/uvloop/sslproto.pxd
@@ -59,7 +59,6 @@ cdef class SSLProtocol:
         object _outgoing_read
         char* _ssl_buffer
         size_t _ssl_buffer_len
-        object _ssl_buffer_view
         SSLProtocolState _state
         size_t _conn_lost
         AppProtocolState _app_state
@@ -83,6 +82,8 @@ cdef class SSLProtocol:
         object _handshake_start_time
         object _handshake_timeout_handle
         object _shutdown_timeout_handle
+
+    cdef inline get_buffer_c(self, size_t n, char** buf, size_t* buf_size)
 
     cdef _set_app_protocol(self, app_protocol)
     cdef _wakeup_waiter(self, exc=*)

--- a/uvloop/sslproto.pxd
+++ b/uvloop/sslproto.pxd
@@ -85,55 +85,55 @@ cdef class SSLProtocol:
 
     cdef inline get_buffer_c(self, size_t n, char** buf, size_t* buf_size)
 
-    cdef _set_app_protocol(self, app_protocol)
-    cdef _wakeup_waiter(self, exc=*)
-    cdef _get_extra_info(self, name, default=*)
-    cdef _set_state(self, SSLProtocolState new_state)
+    cdef inline _set_app_protocol(self, app_protocol)
+    cdef inline _wakeup_waiter(self, exc=*)
+    cdef inline _get_extra_info(self, name, default=*)
+    cdef inline _set_state(self, SSLProtocolState new_state)
 
     # Handshake flow
 
-    cdef _start_handshake(self)
-    cdef _check_handshake_timeout(self)
-    cdef _do_handshake(self)
-    cdef _on_handshake_complete(self, handshake_exc)
+    cdef inline _start_handshake(self)
+    cdef inline _check_handshake_timeout(self)
+    cdef inline _do_handshake(self)
+    cdef inline _on_handshake_complete(self, handshake_exc)
 
     # Shutdown flow
 
-    cdef _start_shutdown(self, object context=*)
-    cdef _check_shutdown_timeout(self)
-    cdef _do_read_into_void(self, object context)
-    cdef _do_flush(self, object context=*)
-    cdef _do_shutdown(self, object context=*)
-    cdef _on_shutdown_complete(self, shutdown_exc)
-    cdef _abort(self, exc)
+    cdef inline _start_shutdown(self, object context=*)
+    cdef inline _check_shutdown_timeout(self)
+    cdef inline _do_read_into_void(self, object context)
+    cdef inline _do_flush(self, object context=*)
+    cdef inline _do_shutdown(self, object context=*)
+    cdef inline _on_shutdown_complete(self, shutdown_exc)
+    cdef inline _abort(self, exc)
 
     # Outgoing flow
 
-    cdef _write_appdata(self, list_of_data, object context)
-    cdef _do_write(self)
-    cdef _process_outgoing(self)
+    cdef inline _write_appdata(self, list_of_data, object context)
+    cdef inline _do_write(self)
+    cdef inline _process_outgoing(self)
 
     # Incoming flow
 
-    cdef _do_read(self)
-    cdef _do_read__buffered(self)
-    cdef _do_read__copied(self)
-    cdef _call_eof_received(self, object context=*)
+    cdef inline _do_read(self)
+    cdef inline _do_read__buffered(self)
+    cdef inline _do_read__copied(self)
+    cdef inline _call_eof_received(self, object context=*)
 
     # Flow control for writes from APP socket
 
-    cdef _control_app_writing(self, object context=*)
-    cdef size_t _get_write_buffer_size(self)
-    cdef _set_write_buffer_limits(self, high=*, low=*)
+    cdef inline _control_app_writing(self, object context=*)
+    cdef inline size_t _get_write_buffer_size(self)
+    cdef inline _set_write_buffer_limits(self, high=*, low=*)
 
     # Flow control for reads to APP socket
 
-    cdef _pause_reading(self)
-    cdef _resume_reading(self, object context)
+    cdef inline _pause_reading(self)
+    cdef inline _resume_reading(self, object context)
 
     # Flow control for reads from SSL socket
 
-    cdef _control_ssl_reading(self)
-    cdef _set_read_buffer_limits(self, high=*, low=*)
-    cdef size_t _get_read_buffer_size(self)
-    cdef _fatal_error(self, exc, message=*)
+    cdef inline _control_ssl_reading(self)
+    cdef inline _set_read_buffer_limits(self, high=*, low=*)
+    cdef inline size_t _get_read_buffer_size(self)
+    cdef inline _fatal_error(self, exc, message=*)

--- a/uvloop/sslproto.pxd
+++ b/uvloop/sslproto.pxd
@@ -83,7 +83,11 @@ cdef class SSLProtocol:
         object _handshake_timeout_handle
         object _shutdown_timeout_handle
 
-    cdef inline get_buffer_c(self, size_t n, char** buf, size_t* buf_size)
+    # Instead of doing python calls, c methods *_impl are called directly
+    # from stream.pyx
+
+    cdef inline get_buffer_impl(self, size_t n, char** buf, size_t* buf_size)
+    cdef inline buffer_updated_impl(self, size_t nbytes)
 
     cdef inline _set_app_protocol(self, app_protocol)
     cdef inline _wakeup_waiter(self, exc=*)

--- a/uvloop/sslproto.pyx
+++ b/uvloop/sslproto.pyx
@@ -204,11 +204,8 @@ cdef class SSLProtocol:
         self._ssl_buffer = <char*>PyMem_RawMalloc(self._ssl_buffer_len)
         if not self._ssl_buffer:
             raise MemoryError()
-        self._ssl_buffer_view = PyMemoryView_FromMemory(
-            self._ssl_buffer, self._ssl_buffer_len, PyBUF_WRITE)
 
     def __dealloc__(self):
-        self._ssl_buffer_view = None
         PyMem_RawFree(self._ssl_buffer)
         self._ssl_buffer = NULL
         self._ssl_buffer_len = 0
@@ -358,7 +355,7 @@ cdef class SSLProtocol:
             self._handshake_timeout_handle.cancel()
             self._handshake_timeout_handle = None
 
-    def get_buffer(self, n):
+    cdef get_buffer_c(self, size_t n, char** buf, size_t* buf_size):
         cdef size_t want = n
         if want > SSL_READ_MAX_SIZE:
             want = SSL_READ_MAX_SIZE
@@ -367,11 +364,21 @@ cdef class SSLProtocol:
             if not self._ssl_buffer:
                 raise MemoryError()
             self._ssl_buffer_len = want
-            self._ssl_buffer_view = PyMemoryView_FromMemory(
-                self._ssl_buffer, want, PyBUF_WRITE)
-        return self._ssl_buffer_view
 
-    def buffer_updated(self, nbytes):
+        buf[0] = self._ssl_buffer
+        buf_size[0] = self._ssl_buffer_len
+
+    def get_buffer(self, size_t n):
+        # This pure python call is still used by some very peculiar test cases
+        
+        cdef:
+            char* buf
+            size_t buf_size
+
+        self.get_buffer_c(n, &buf, &buf_size)
+        return PyMemoryView_FromMemory(buf, buf_size, PyBUF_WRITE)
+
+    def buffer_updated(self, size_t nbytes):
         self._incoming_write(PyMemoryView_FromMemory(
             self._ssl_buffer, nbytes, PyBUF_WRITE))
 

--- a/uvloop/sslproto.pyx
+++ b/uvloop/sslproto.pyx
@@ -561,7 +561,7 @@ cdef class SSLProtocol:
             new_MethodHandle(self._loop,
                              "SSLProtocol._do_read",
                              <method_t> self._do_read,
-                             None,
+                             None, # current context is good
                              self))
 
     # Shutdown flow
@@ -761,7 +761,7 @@ cdef class SSLProtocol:
                         new_MethodHandle(self._loop,
                                          "SSLProtocol._do_read",
                                          <method_t>self._do_read,
-                                         None,
+                                         None, # current context is good
                                          self))
         except ssl_SSLAgainErrors as exc:
             pass

--- a/uvloop/sslproto.pyx
+++ b/uvloop/sslproto.pyx
@@ -370,7 +370,7 @@ cdef class SSLProtocol:
 
     def get_buffer(self, size_t n):
         # This pure python call is still used by some very peculiar test cases
-        
+
         cdef:
             char* buf
             size_t buf_size

--- a/uvloop/sslproto.pyx
+++ b/uvloop/sslproto.pyx
@@ -548,7 +548,6 @@ cdef class SSLProtocol:
         if self._app_state == STATE_INIT:
             self._app_state = STATE_CON_MADE
             self._app_protocol.connection_made(self._get_app_transport())
-
         self._wakeup_waiter()
 
         # We should wakeup user code before sending the first data below. In
@@ -561,7 +560,7 @@ cdef class SSLProtocol:
             new_MethodHandle(self._loop,
                              "SSLProtocol._do_read",
                              <method_t> self._do_read,
-                             None, # current context is good
+                             None,  # current context is good
                              self))
 
     # Shutdown flow
@@ -761,7 +760,7 @@ cdef class SSLProtocol:
                         new_MethodHandle(self._loop,
                                          "SSLProtocol._do_read",
                                          <method_t>self._do_read,
-                                         None, # current context is good
+                                         None,  # current context is good
                                          self))
         except ssl_SSLAgainErrors as exc:
             pass
@@ -797,12 +796,10 @@ cdef class SSLProtocol:
                     data.append(chunk)
         except ssl_SSLAgainErrors as exc:
             pass
-
         if one:
             self._app_protocol.data_received(first)
         elif not zero:
             self._app_protocol.data_received(b''.join(data))
-
         if not chunk:
             # close_notify
             self._call_eof_received()
@@ -892,12 +889,11 @@ cdef class SSLProtocol:
             self._app_reading_paused = False
             if self._state == WRAPPED:
                 self._loop._call_soon_handle(
-                    new_MethodHandle1(self._loop,
-                                      "SSLProtocol._do_read",
-                                      <method1_t>self._do_read,
-                                      context,
-                                      self,
-                                      context))
+                    new_MethodHandle(self._loop,
+                                     "SSLProtocol._do_read",
+                                     <method_t>self._do_read,
+                                     context,
+                                     self))
 
     # Flow control for reads from SSL socket
 


### PR DESCRIPTION
After profiling my app with perf I identified a couple of thing that make SSLProtocol a little bit faster:
* SSLProtocol.get_buffer and buffer_updated can be called directly from UVStream since it is our own type and we know it's definition
* Added inline directive to all private methods of SSLProtocol