### PR TITLE
Optimize run_in_context functions

### DIFF
--- a/uvloop/loop.pyx
+++ b/uvloop/loop.pyx
@@ -98,7 +98,11 @@ cdef inline run_in_context(context, method):
     # See also: edgedb/edgedb#2222
     Py_INCREF(method)
     try:
-        return context.run(method)
+        Context_Enter(context)
+        try:
+            return method()
+        finally:
+            Context_Exit(context)
     finally:
         Py_DECREF(method)
 
@@ -106,7 +110,11 @@ cdef inline run_in_context(context, method):
 cdef inline run_in_context1(context, method, arg):
     Py_INCREF(method)
     try:
-        return context.run(method, arg)
+        Context_Enter(context)
+        try:
+            return method(arg)
+        finally:
+            Context_Exit(context)
     finally:
         Py_DECREF(method)
 
@@ -114,7 +122,11 @@ cdef inline run_in_context1(context, method, arg):
 cdef inline run_in_context2(context, method, arg1, arg2):
     Py_INCREF(method)
     try:
-        return context.run(method, arg1, arg2)
+        Context_Enter(context)
+        try:
+            return method(arg1, arg2)
+        finally:
+            Context_Exit(context)
     finally:
         Py_DECREF(method)
 


### PR DESCRIPTION
From perf, callstack before the change:
```
--54.22%--__pyx_f_6uvloop_4loop___uv_stream_on_read
         |          
          --52.82%--__pyx_f_6uvloop_4loop_run_in_context1
                    |          
                     --51.06%--cfunction_vectorcall_FASTCALL_KEYWORDS
                               context_run
                               |          
                                --50.49%--_PyObject_VectorcallTstate.lto_priv.18
                                          |          
                                           --50.28%--method_vectorcall
                                                     |          
                                                      --49.45%--__pyx_pw_6picows_6picows_10WSProtocol_13data_received


```
After the change:
```
--51.71%--__pyx_f_6uvloop_4loop___uv_stream_on_read
         |          
          --50.42%--__pyx_f_6uvloop_4loop_run_in_context1
                    |          
                     --49.13%--__pyx_pw_6picows_6picows_10WSProtocol_13data_received
```