### PR TITLE
Improve performance of ssl reads

### DIFF
--- a/uvloop/sslproto.pxd
+++ b/uvloop/sslproto.pxd
@@ -114,8 +114,8 @@ cdef class SSLProtocol:
 
     # Incoming flow
 
-    cdef _do_read(self)
-    cdef _do_read__buffered(self)
+    cdef _do_read(self, bint use_pending_size)
+    cdef _do_read__buffered(self, bint use_pending_size)
     cdef _do_read__copied(self)
     cdef _call_eof_received(self, object context=*)
 

--- a/uvloop/sslproto.pxd
+++ b/uvloop/sslproto.pxd
@@ -53,6 +53,7 @@ cdef class SSLProtocol:
         object _sslobj
         object _sslobj_read
         object _sslobj_write
+        object _sslobj_pending
         object _incoming
         object _incoming_write
         object _outgoing
@@ -114,8 +115,8 @@ cdef class SSLProtocol:
 
     # Incoming flow
 
-    cdef _do_read(self, bint use_pending_size)
-    cdef _do_read__buffered(self, bint use_pending_size)
+    cdef _do_read(self)
+    cdef _do_read__buffered(self)
     cdef _do_read__copied(self)
     cdef _call_eof_received(self, object context=*)
 

--- a/uvloop/sslproto.pyx
+++ b/uvloop/sslproto.pyx
@@ -742,18 +742,17 @@ cdef class SSLProtocol:
             # We have to keep calling read until it throw SSLWantReadError.
             # However, throwing SSLWantReadError is very expensive even in
             # the master trunk of cpython.
-            #
+            # See https://github.com/python/cpython/issues/123954
 
             # One way to reduce reliance on SSLWantReadError is to check
-            # self._incoming.pending > 0 or SSLObject.pending() > 0.
+            # self._incoming.pending > 0 and SSLObject.pending() > 0.
             # SSLObject.read may still throw SSLWantReadError even when
-            # self._incoming.pending > 0 but this should happen relatively
-            # rarely, only when ssl frame is partially received.
+            # self._incoming.pending > 0 SSLObject.pending() == 0,
+            # but this should happen relatively rarely, only when ssl frame
+            # is partially received.
 
             # This optimization works really well especially for peers
             # exchanging small messages and wanting to have minimal latency.
-
-            # On a side note:
 
             # self._incoming.pending means how much data hasn't
             # been processed by ssl yet (read: "still encrypted"). The final

--- a/uvloop/sslproto.pyx
+++ b/uvloop/sslproto.pyx
@@ -816,8 +816,8 @@ cdef class SSLProtocol:
             bint zero = True, one = False
 
         try:
-            while (<size_t>self._incoming.pending > 0 or
-                   self._sslobj_pending() > 0):
+            while (<Py_ssize_t>self._incoming.pending > 0 or
+                   <Py_ssize_t>self._sslobj_pending() > 0):
                 chunk = self._sslobj_read(SSL_READ_MAX_SIZE)
                 if not chunk:
                     break

--- a/uvloop/sslproto.pyx
+++ b/uvloop/sslproto.pyx
@@ -817,7 +817,7 @@ cdef class SSLProtocol:
 
         try:
             while (<size_t>self._incoming.pending > 0 or
-                   self._sslobj.pending() > 0):
+                   self._sslobj_pending() > 0):
                 chunk = self._sslobj_read(SSL_READ_MAX_SIZE)
                 if not chunk:
                     break


### PR DESCRIPTION
SSLWantReadError is expensive.

https://github.com/python/cpython/issues/123954

This PR tries to predict that there will be SSLWantReadError by checking incoming.pending and SSLObject.pending() first.
This check works in 99% of cases. For the rest 1% we still rely on SSLWantReadError

