### PR TITLE
Support any number of flags in UVLOOP_OPT_CFLAGS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ import os.path
 import pathlib
 import platform
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -23,7 +24,7 @@ from setuptools.command.sdist import sdist
 
 CYTHON_DEPENDENCY = 'Cython~=3.0'
 MACHINE = platform.machine()
-MODULES_CFLAGS = [os.getenv('UVLOOP_OPT_CFLAGS', '-O2')]
+MODULES_CFLAGS = shlex.split(os.getenv('UVLOOP_OPT_CFLAGS', '-O2'))
 _ROOT = pathlib.Path(__file__).parent
 LIBUV_DIR = str(_ROOT / 'vendor' / 'libuv')
 LIBUV_BUILD_DIR = str(_ROOT / 'build' / 'libuv-{}'.format(MACHINE))


### PR DESCRIPTION
Use `shlex.split()` to split the flags in `UVLOOP_OPT_FLAGS`, permitting the user to pass any number of flags rather than exactly one.  This can be used e.g. to pass `-O2 -flto`.