### PR TITLE
uvloop 0.21.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
       run: |
         brew install gnu-sed libtool autoconf automake
 
-    - uses: pypa/cibuildwheel@bd033a44476646b606efccdd5eed92d5ea1d77ad  # v2.20.0
+    - uses: pypa/cibuildwheel@7940a4c0e76eb2030e473a5f864f291f63ee879b  # v2.21.3
       env:
         CIBW_BUILD_VERBOSITY: 1
         CIBW_BUILD: ${{ matrix.cibw_python }}

--- a/uvloop/_version.py
+++ b/uvloop/_version.py
@@ -10,4 +10,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = '0.21.0beta1'
+__version__ = '0.21.0'


### PR DESCRIPTION
Changes
=======

* Add cleanup_socket param on create_unix_server()
  (#623) (by @fantix in d6114d2)

Fixes
=====

* Use cythonized SO_REUSEPORT rather than the unwrapped native one. (#609)
  (by @ptribble in 4083a94e for #550)

* UDP errors should result in protocol.error_received (#601)
  (by @jensbjorgensen in 3c3bbeff)

* Updates for Cython3 (#587)
  (by @alan-brooks in 3fba9fab for #587)

* Test with Python 3.13 (#610)
  (by @edgarrmondragon in fb5a139)