### PR TITLE
Use Cython `enum` for `__PREALLOCED_BUFS`

### DIFF
--- a/uvloop/handles/stream.pyx
+++ b/uvloop/handles/stream.pyx
@@ -1,8 +1,5 @@
-cdef extern from *:
-    '''
-    enum {__PREALLOCED_BUFS = 4};
-    '''
-    const bint __PREALLOCED_BUFS
+cdef enum:
+    __PREALLOCED_BUFS = 4
 
 
 @cython.no_gc_clear


### PR DESCRIPTION
Follow up to this discussion: https://github.com/MagicStack/uvloop/pull/587#discussion_r1800388359

Simplify the code to use just a Cython `enum`. Also drop the `bint` type, which doesn't make sense given the value assigned.