### PR TITLE
Add thread name prefix to the default thread pool executor

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -869,6 +869,21 @@ class TestBaseUV(_TestBase, UVTestCase):
         self.loop.run_until_complete(fut)
         self.assertEqual(handle.when(), when)
 
+    def test_thread_name_prefix_in_default_executor(self):
+        called = []
+
+        def cb():
+            called.append(threading.current_thread().name)
+
+        async def runner():
+            await self.loop.run_in_executor(None, cb)
+
+        self.loop.run_until_complete(runner())
+
+        self.assertEqual(len(called), 1)
+        self.assertTrue(called[0] is not None)
+        self.assertTrue(called[0].startswith("uvloop"))
+
 
 class TestBaseAIO(_TestBase, AIOTestCase):
     pass

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -799,6 +799,26 @@ if __name__ == "__main__":
         elif result.returncode != 0:
             self.fail(result.stdout.strip())
 
+    def test_thread_name_prefix_in_default_executor(self):
+        if self.implementation == "asyncio" and sys.version_info < (3, 9):
+            raise unittest.SkipTest(
+                "thread_name_prefix was added in CPython 3.9"
+            )
+
+        called = []
+
+        def cb():
+            called.append(threading.current_thread().name)
+
+        async def runner():
+            await self.loop.run_in_executor(None, cb)
+
+        self.loop.run_until_complete(runner())
+
+        self.assertEqual(len(called), 1)
+        self.assertTrue(called[0] is not None)
+        self.assertTrue(called[0].startswith(self.implementation))
+
 
 class TestBaseUV(_TestBase, UVTestCase):
 
@@ -937,21 +957,6 @@ class TestBaseUV(_TestBase, UVTestCase):
         when = handle.when()
         self.loop.run_until_complete(fut)
         self.assertEqual(handle.when(), when)
-
-    def test_thread_name_prefix_in_default_executor(self):
-        called = []
-
-        def cb():
-            called.append(threading.current_thread().name)
-
-        async def runner():
-            await self.loop.run_in_executor(None, cb)
-
-        self.loop.run_until_complete(runner())
-
-        self.assertEqual(len(called), 1)
-        self.assertTrue(called[0] is not None)
-        self.assertTrue(called[0].startswith("uvloop"))
 
 
 class TestBaseAIO(_TestBase, AIOTestCase):

--- a/uvloop/loop.pyx
+++ b/uvloop/loop.pyx
@@ -2741,7 +2741,7 @@ cdef class Loop:
             # Only check when the default executor is being used
             self._check_default_executor()
             if executor is None:
-                executor = cc_ThreadPoolExecutor()
+                executor = cc_ThreadPoolExecutor(thread_name_prefix='uvloop')
                 self._default_executor = executor
 
         return aio_wrap_future(executor.submit(func, *args), loop=self)


### PR DESCRIPTION
Set `thread_name_prefix` on default `ThreadPoolExector` instance. With this it's easier to distinguish `uvloop` threads.

Fixes #562 
Mirrors python/cpython#18458