### PR TITLE
Fix SSLProtocol.connection_lost not being called when underlying socket is closed

### DIFF
--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -117,8 +117,10 @@ class _TestAioHTTP(tb.SSLTestCase):
         self.loop.run_until_complete(stop())
 
     def test_aiohttp_connection_lost_when_busy(self):
-        if self.implementation == 'asyncio':
-            raise unittest.SkipTest('bug in asyncio #118950 tests in CPython.')
+        if self.implementation == 'asyncio' and sys.version_info < (3, 13):
+            raise unittest.SkipTest(
+                "asyncio bug #118950, fixed in CPython 3.13+"
+            )
 
         cert = tb._cert_fullname(__file__, 'ssl_cert.pem')
         key = tb._cert_fullname(__file__, 'ssl_key.pem')
@@ -131,8 +133,8 @@ class _TestAioHTTP(tb.SSLTestCase):
         async def handler(request):
             ws = aiohttp.web.WebSocketResponse()
             await ws.prepare(request)
-            async for msg in ws:
-                print("Received:", msg.data)
+            async for _msg in ws:
+                pass
             return ws
 
         app.router.add_get('/', handler)

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -117,9 +117,12 @@ class _TestAioHTTP(tb.SSLTestCase):
         self.loop.run_until_complete(stop())
 
     def test_aiohttp_connection_lost_when_busy(self):
-        if self.implementation == 'asyncio' and sys.version_info < (3, 13):
+        if self.implementation == 'asyncio' and (
+            sys.version_info < (3, 12, 8)
+            or sys.version_info[:3] == (3, 13, 0)
+        ):
             raise unittest.SkipTest(
-                "asyncio bug #118950, fixed in CPython 3.13+"
+                "asyncio bug #118950, fixed in CPython 3.12.8 and 3.13.1"
             )
 
         cert = tb._cert_fullname(__file__, 'ssl_cert.pem')

--- a/tests/test_tcp.py
+++ b/tests/test_tcp.py
@@ -3315,8 +3315,10 @@ class _TestSSL(tb.SSLTestCase):
         self.loop.run_until_complete(run_main())
 
     def test_connection_lost_when_busy(self):
-        if self.implementation == 'asyncio':
-            raise unittest.SkipTest('bug in asyncio #118950 tests in CPython.')
+        if self.implementation == 'asyncio' and sys.version_info < (3, 13):
+            raise unittest.SkipTest(
+                "asyncio bug #118950, fixed in CPython 3.13+"
+            )
 
         ssl_context = self._create_server_ssl_context(
             self.ONLYCERT, self.ONLYKEY)

--- a/tests/test_tcp.py
+++ b/tests/test_tcp.py
@@ -3315,9 +3315,12 @@ class _TestSSL(tb.SSLTestCase):
         self.loop.run_until_complete(run_main())
 
     def test_connection_lost_when_busy(self):
-        if self.implementation == 'asyncio' and sys.version_info < (3, 13):
+        if self.implementation == 'asyncio' and (
+            sys.version_info < (3, 12, 8)
+            or sys.version_info[:3] == (3, 13, 0)
+        ):
             raise unittest.SkipTest(
-                "asyncio bug #118950, fixed in CPython 3.13+"
+                "asyncio bug #118950, fixed in CPython 3.12.8 and 3.13.1"
             )
 
         ssl_context = self._create_server_ssl_context(

--- a/uvloop/sslproto.pyx
+++ b/uvloop/sslproto.pyx
@@ -37,7 +37,7 @@ cdef class _SSLProtocolTransport:
         return self._ssl_protocol._app_protocol
 
     def is_closing(self):
-        return self._closed
+        return self._closed or self._ssl_protocol._is_transport_closing()
 
     def close(self):
         """Close the transport.
@@ -315,6 +315,9 @@ cdef class SSLProtocol:
                                                         context)
             self._app_transport_created = True
         return self._app_transport
+
+    def _is_transport_closing(self):
+        return self._transport is not None and self._transport.is_closing()
 
     def connection_made(self, transport):
         """Called when the low-level connection is made.


### PR DESCRIPTION
As as a follow up to https://github.com/python/cpython/issues/118950, the fix to the issue in CPython's `asyncio` module seemed to translate quite well onto uvloop, and my failing tests effectively work both using the underlying socket streams and using higher level libraries such as aiohttp where the issue originally appeared.

As a quick description the issue occurs when an underlying socket is broken (typically accompanied by a BrokenPipe error), in uvloop this translates to the `system.write` call returning some error code which is handled in the exact same way by calling `fatal_error` as the sister implementation in asyncio. This implementation has a similar pitfall when the writer loop actively is ran in some kind of loop where the `call_soon` `connection_lost` function that is supposed to mark the transport as closed (leading to an error being thrown) never is called, leading to some pretty annoying invalid state. But these details are mostly tested using asyncio but the same symptoms and underlying reasons seems to effect this implemention after some light testing, but there might be more to the story here.

These changes are effectively a port of https://github.com/python/cpython/pull/118960 with absolutely no difference except the more thorough tests reflecting the existing tests provided.

I have initially just skipped all asyncio tests as the upstream PR has yet to be merged but most likely we will see it in a future 3.12 release and newer.

Feel free to address any issues or things i've left out from here.