### PR TITLE
Add note about Python version to performance claims in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,10 @@ The project documentation can be found
 Performance
 -----------
 
-uvloop makes asyncio 2-4x faster.
+**These benchmarks were run in old version of Python (3.5). Differences are not as great with
+newer Python versions.**
+
+uvloop makes asyncio 2-4x faster in old Python versions when asyncio was not yet mature.
 
 .. image:: https://raw.githubusercontent.com/MagicStack/uvloop/master/performance.png
     :target: http://magic.io/blog/uvloop-blazing-fast-python-networking/


### PR DESCRIPTION
Performance claims are not so valid in newer Python versions. Add this to the README. Benchmark should include different Python versions. For now, just add the version on which the benchmarks were run in. Related issue https://github.com/MagicStack/uvloop/issues/566 