### PR TITLE
Fix cpython imports

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ if vi < (3, 8):
     raise RuntimeError('uvloop requires Python 3.8 or greater')
 
 if sys.platform in ('win32', 'cygwin', 'cli'):
-    raise RuntimeError('uvloop does not support Windows at the moment')
+    raise RuntimeError('uvloop does not support Windows at the moment, try installing winloop instead')
 
 import os
 import os.path

--- a/uvloop/loop.pyx
+++ b/uvloop/loop.pyx
@@ -28,17 +28,18 @@ from libc.stdint cimport uint64_t
 from libc.string cimport memset, strerror, memcpy
 from libc cimport errno
 
-from cpython cimport PyObject
-from cpython cimport PyErr_CheckSignals, PyErr_Occurred
-from cpython cimport PyThread_get_thread_ident
-from cpython cimport Py_INCREF, Py_DECREF, Py_XDECREF, Py_XINCREF
-from cpython cimport (
-    PyObject_GetBuffer, PyBuffer_Release, PyBUF_SIMPLE,
-    Py_buffer, PyBytes_AsString, PyBytes_CheckExact,
-    PyBytes_AsStringAndSize,
-    Py_SIZE, PyBytes_AS_STRING, PyBUF_WRITABLE
+from cpython.bytes cimport PyBytes_AsString, PyBytes_CheckExact, PyBytes_AsStringAndSize, PyBytes_AS_STRING
+from cpython.buffer cimport (
+    PyObject_GetBuffer, PyBuffer_Release, PyBUF_SIMPLE, PyBUF_WRITABLE
 )
+
+from cpython.exc cimport PyErr_CheckSignals, PyErr_Occurred
+from cpython.object cimport PyObject, Py_SIZE
+
 from cpython.pycapsule cimport PyCapsule_New, PyCapsule_GetPointer
+
+from cpython.pythread cimport PyThread_get_thread_ident
+from cpython.ref cimport Py_INCREF, Py_DECREF, Py_XDECREF, Py_XINCREF
 
 from . import _noop
 


### PR DESCRIPTION
C imports from cpython alone are deprecated and warned against & discouraged. I have already migrated and made these changes to [the Winloop Project](https://github.com/Vizonex/Winloop/commit/c422d4fedd18656691469950a01198d1b346e41b) Know that our code-spaces are a bit different from this one due to different operating systems being used. However I did my best to keep the imports in alphabetical order.


