### PR TITLE
More changes for Python 3.14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,7 @@ jobs:
         - "cp311-*"
         - "cp312-*"
         - "cp313-*"
+        - "cp314-*"
         cibw_arch: ["x86_64", "aarch64", "universal2"]
         exclude:
           - os: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,7 @@ jobs:
         - "3.11"
         - "3.12"
         - "3.13"
+        - "3.14"
         os: [ubuntu-latest, macos-latest]
 
     env:

--- a/uvloop/__init__.py
+++ b/uvloop/__init__.py
@@ -3,12 +3,6 @@ import typing as _typing
 import sys as _sys
 import warnings as _warnings
 
-try:
-    from asyncio.events import BaseDefaultEventLoopPolicy as __BasePolicy
-except ImportError:
-    # Python 3.14
-    from asyncio import DefaultEventLoopPolicy as __BasePolicy
-
 from . import includes as __includes  # NOQA
 from .loop import Loop as __BaseLoop  # NOQA
 from ._version import __version__  # NOQA
@@ -143,7 +137,7 @@ def _cancel_all_tasks(loop: __asyncio.AbstractEventLoop) -> None:
             })
 
 
-class EventLoopPolicy(__BasePolicy):
+class EventLoopPolicy(__asyncio.AbstractEventLoopPolicy):
     """Event loop policy.
 
     The preferred way to make your application use uvloop:

--- a/uvloop/__init__.py
+++ b/uvloop/__init__.py
@@ -3,7 +3,11 @@ import typing as _typing
 import sys as _sys
 import warnings as _warnings
 
-from asyncio.events import BaseDefaultEventLoopPolicy as __BasePolicy
+try:
+    from asyncio.events import BaseDefaultEventLoopPolicy as __BasePolicy
+except ImportError:
+    # Python 3.14
+    from asyncio import DefaultEventLoopPolicy as __BasePolicy
 
 from . import includes as __includes  # NOQA
 from .loop import Loop as __BaseLoop  # NOQA


### PR DESCRIPTION
Fixed **BaseDefaultEventLoopPolicy** issue.

Pending (https://github.com/MagicStack/uvloop/pull/638/files):

Removed: asyncio.AbstractChildWatcher, asyncio.SafeChildWatcher
In favor of: asyncio.create_subprocess_exec / asyncio.create_subprocess_shell

uvloop/loop.pyx:
 2917          if sig == uv.SIGCHLD:
 2918              if (hasattr(callback, '__self__') and
 2919:                     isinstance(callback.__self__, aio_AbstractChildWatcher)):
 2920  
 2921                  warnings_warn(

uvloop/includes/stdlib.pxi:
   45  cdef aio_set_running_loop = getattr(asyncio, '_set_running_loop', None)
   46  cdef aio_debug_wrapper = getattr(asyncio.coroutines, 'debug_wrapper', None)
   47: cdef aio_AbstractChildWatcher = asyncio.AbstractChildWatcher
   48  cdef aio_Transport = asyncio.Transport
   49  cdef aio_FlowControlMixin = asyncio.transports._FlowControlMixin
