### PR TITLE
uvloop 0.22.0

### DIFF
--- a/uvloop/_version.py
+++ b/uvloop/_version.py
@@ -10,4 +10,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = '0.21.0'
+__version__ = '0.22.0'


### PR DESCRIPTION
Changes
=======

* Fixes for Python 3.14 (#638)
  (by @graingert @hroncok @paulocheque @fantix in 46456b6a for #637)

* Add free-threading support (#693)
  (by @kumaraditya303 in 286b3707 for #642)

Fixes
=====

* Use Cython `enum` for `__PREALLOCED_BUFS` (#634)
  (by @jakirkham in 7bb12a17 for #634)

* test: fix getaddrinfo test (#663)
  (by @fantix in 56807922 for #663)

* test: fix task name for Python 3.13.3/3.14 (#662)
  (by @cjwatson in 96b7ed31 for #662)