### PR TITLE
Get rid of wheel as a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ docs = [
 [build-system]
 requires = [
     "setuptools>=60",
-    "wheel",
     "Cython~=3.1",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
https://setuptools.pypa.io/en/latest/userguide/quickstart.html#basic-use

> Historically this documentation has unnecessarily listed `wheel` in the `requires` list, and many projects still do that. This is not recommended, as the backend no longer requires the `wheel` package, and listing it explicitly causes it to be unnecessarily required for source distribution builds. You should only include `wheel` in `requires` if you need to explicitly access it during build time (e.g. if your project needs a `setup.py` script that imports `wheel`).