### PR TITLE
PEP 639 compliance

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,4 +6,4 @@ recursive-include vendor/libuv *
 recursive-exclude vendor/libuv/.git *
 recursive-exclude vendor/libuv/docs *
 recursive-exclude vendor/libuv/img *
-include LICENSE-MIT LICENSE-APACHE README.rst Makefile performance.png .flake8 mypy.ini
+include Makefile performance.png .flake8 mypy.ini

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ description = "Fast implementation of asyncio event loop on top of libuv"
 authors = [{name = "Yury Selivanov", email = "yury@magic.io"}]
 requires-python = '>=3.8.1'
 readme = "README.rst"
-license = {text = "MIT License"}
+license = "MIT OR Apache-2.0"
+license-files = ["LICENSE-APACHE", "LICENSE-MIT"]
 dynamic = ["version"]
 keywords = [
     "asyncio",
@@ -14,8 +15,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Framework :: AsyncIO",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Apache Software License",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: POSIX",
     "Operating System :: MacOS :: MacOS X",
     "Programming Language :: Python :: 3 :: Only",
@@ -46,7 +45,7 @@ test = [
 ]
 dev = [
     'packaging>=20',
-    'setuptools>=60',
+    'setuptools>=77.0.3',
     'Cython~=3.1',
 ]
 docs = [
@@ -58,7 +57,7 @@ docs = [
 [build-system]
 requires = [
     "packaging>=20",
-    "setuptools>=60",
+    "setuptools>=77.0.3",
     "Cython~=3.1",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Requires setuptools ≥ 77.0.3 which requires Python 3.9, so this can wait until Python 3.8 support is dropped.

Fixes #684 (partially).