### PR TITLE
Update the example to work with 3.14

### DIFF
--- a/examples/bench/echoclient.py
+++ b/examples/bench/echoclient.py
@@ -4,12 +4,15 @@
 
 import argparse
 import concurrent.futures
+import multiprocessing
 import socket
 import ssl
 import time
 
 
 if __name__ == '__main__':
+    multiprocessing.set_start_method("fork")
+
     parser = argparse.ArgumentParser()
     parser.add_argument('--msize', default=1000, type=int,
                         help='message size in bytes')


### PR DESCRIPTION
The benchmark relies on fork being the default start method, which is no longer the case in 3.14.