### PR TITLE
Increase test_issue39_regression alarm time

### DIFF
--- a/tests/test_regr1.py
+++ b/tests/test_regr1.py
@@ -107,7 +107,7 @@ class TestIssue39Regr(tb.UVTestCase):
         'no need to test on macOS where spawn is used instead of fork')
     def test_issue39_regression(self):
         signal.signal(signal.SIGALRM, self.on_alarm)
-        signal.alarm(5)
+        signal.alarm(10)
 
         try:
             self.running = True


### PR DESCRIPTION
On Debian/riscv64 buildds 5 seconds were not enough with Python 3.14:
https://buildd.debian.org/status/fetch.php?pkg=uvloop&arch=riscv64&ver=0.22.1%2Bds1-1.1&stamp=1767098985&raw=0