### PR TITLE
Fix test `test_create_connection_open_con_addr` with Python 3.13.9+

### DIFF
--- a/tests/test_tcp.py
+++ b/tests/test_tcp.py
@@ -405,7 +405,7 @@ class _TestTCP:
             self.assertEqual(await reader.readexactly(2), b'OK')
 
             re = r'(a bytes-like object)|(must be byte-ish)'
-            if sys.version_info >= (3, 14):
+            if sys.version_info >= (3, 13, 9):
                 re += r'|(must be a bytes, bytearray, or memoryview object)'
             with self.assertRaisesRegex(TypeError, re):
                 writer.write('AAAA')


### PR DESCRIPTION
Fixed #701