### PR TITLE
Fix race conditions on `loop._ready_len`

### DIFF
--- a/uvloop/loop.pxd
+++ b/uvloop/loop.pxd
@@ -50,7 +50,6 @@ cdef class Loop:
         object _default_executor
         object _ready
         set _queued_streams, _executing_streams
-        Py_ssize_t _ready_len
 
         set _servers
 

--- a/uvloop/loop.pyx
+++ b/uvloop/loop.pyx
@@ -181,7 +181,6 @@ cdef class Loop:
         self._queued_streams = set()
         self._executing_streams = set()
         self._ready = col_deque()
-        self._ready_len = 0
 
         self.handler_async = UVAsync.new(
             self, <method_t>self._on_wake, self)
@@ -440,7 +439,7 @@ cdef class Loop:
             self.handler_async.send()
 
     cdef _on_wake(self):
-        if ((self._ready_len > 0 or self._stopping) and
+        if ((len(self._ready) > 0 or self._stopping) and
                 not self.handler_idle.running):
             self.handler_idle.start()
 
@@ -481,8 +480,7 @@ cdef class Loop:
         if len(self._queued_streams):
             self._exec_queued_writes()
 
-        self._ready_len = len(self._ready)
-        if self._ready_len == 0 and self.handler_idle.running:
+        if len(self._ready) == 0 and self.handler_idle.running:
             self.handler_idle.stop()
 
         if self._stopping:
@@ -570,7 +568,6 @@ cdef class Loop:
         for cb_handle in self._ready:
             cb_handle.cancel()
         self._ready.clear()
-        self._ready_len = 0
 
         if self._polls:
             for poll_handle in self._polls.values():
@@ -672,7 +669,6 @@ cdef class Loop:
     cdef inline _append_ready_handle(self, Handle handle):
         self._check_closed()
         self._ready.append(handle)
-        self._ready_len += 1
 
     cdef inline _call_soon_handle(self, Handle handle):
         self._append_ready_handle(handle)


### PR DESCRIPTION
This is a simple PR that fixes #720 by removing `loop._ready_len` in favor of `len(loop._ready)`. The attribute was probably added as a premature optimization (it does not affect performance even in edge cases), but it leads to race conditions both between worker threads calling `loop.call_soon_threadsafe()` and between any such worker thread and the event loop, since `loop._ready_len` is updated in a non-thread-safe manner (free-threading).