### PR TITLE
fix: replace pkg_resources with packaging for setuptools 82+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ class uvloop_build_ext(build_ext):
                         need_cythonize = True
 
         if need_cythonize:
-            import pkg_resources
+            from packaging.requirements import Requirement
 
             # Double check Cython presence in case setup_requires
             # didn't go into effect (most likely because someone
@@ -121,8 +121,8 @@ class uvloop_build_ext(build_ext):
                     'please install {} to compile uvloop from source'.format(
                         CYTHON_DEPENDENCY))
 
-            cython_dep = pkg_resources.Requirement.parse(CYTHON_DEPENDENCY)
-            if Cython.__version__ not in cython_dep:
+            cython_dep = Requirement(CYTHON_DEPENDENCY)
+            if Cython.__version__ not in str(cython_dep.specifier):
                 raise RuntimeError(
                     'uvloop requires {}, got Cython=={}'.format(
                         CYTHON_DEPENDENCY, Cython.__version__


### PR DESCRIPTION
## Summary

pkg_resources was removed from setuptools 82.0.0 (PEP 740, Feb 2026). This breaks uvloop installation when built from source with the latest setuptools.

## Fix

Replace pkg_resources.Requirement.parse() with the stdlib packaging.requirements.Requirement (available since Python 3.8):

- Removed: import pkg_resources  
- Removed: pkg_resources.Requirement.parse(CYTHON_DEPENDENCY)
- Added: from packaging.requirements import Requirement
- Added: Requirement(CYTHON_DEPENDENCY)

The version comparison is updated to use specifier string comparison.

## Testing

pip install setuptools>=82
pip install uvloop  # should work without pkg_resources error
python -c "import uvloop"



Fixes #729