### PR TITLE
fix(build): use packaging instead of relying on pkg_resources from setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,9 @@ test = [
     'mypy>=0.800',
 ]
 dev = [
+    'packaging>=20',
     'setuptools>=60',
-    'Cython~=3.0',
+    'Cython~=3.1',
 ]
 docs = [
     'Sphinx~=4.1.2',
@@ -56,6 +57,7 @@ docs = [
 
 [build-system]
 requires = [
+    "packaging>=20",
     "setuptools>=60",
     "wheel",
     "Cython~=3.1",

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from setuptools.command.build_ext import build_ext
 from setuptools.command.sdist import sdist
 
 
-CYTHON_DEPENDENCY = 'Cython~=3.0'
+CYTHON_DEPENDENCY = 'Cython~=3.1'
 MACHINE = platform.machine()
 MODULES_CFLAGS = [os.getenv('UVLOOP_OPT_CFLAGS', '-O2')]
 _ROOT = pathlib.Path(__file__).parent
@@ -108,7 +108,7 @@ class uvloop_build_ext(build_ext):
                         need_cythonize = True
 
         if need_cythonize:
-            import pkg_resources
+            from packaging.requirements import Requirement
 
             # Double check Cython presence in case setup_requires
             # didn't go into effect (most likely because someone
@@ -121,8 +121,8 @@ class uvloop_build_ext(build_ext):
                     'please install {} to compile uvloop from source'.format(
                         CYTHON_DEPENDENCY))
 
-            cython_dep = pkg_resources.Requirement.parse(CYTHON_DEPENDENCY)
-            if Cython.__version__ not in cython_dep:
+            cython_dep = Requirement(CYTHON_DEPENDENCY)
+            if not cython_dep.specifier.contains(Cython.__version__):
                 raise RuntimeError(
                     'uvloop requires {}, got Cython=={}'.format(
                         CYTHON_DEPENDENCY, Cython.__version__


### PR DESCRIPTION
When trying to build uvloop locally, I ended up encountering the issues mentioned in https://github.com/pypa/setuptools/issues/5174

Reliance of `pkg_resources` causes `pip install -e .` to break given `setuptools>60` build requirement pulls setuptools 82+. While a plausible fix is to setup a constraint like `,<82`, I thought it'd be better to move to use `packaging` given the purpose `pkg_resources` was being used for (version checking) to avoid constraining downstream builders.

I also made sure the Cython versions were aligned to `~=3.1`, seems like misalignment was introduced after https://github.com/MagicStack/uvloop/pull/693

Disclosure (because this seems needed nowadays): This PR is made by human-only contribution without AI usage.

Closes https://github.com/MagicStack/uvloop/issues/729