### PR TITLE
feat(loop): support eager_start in loop.create_task

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -604,6 +604,36 @@ class _TestBase:
         self.loop.set_task_factory(None)
         self.assertIsNone(self.loop.get_task_factory())
 
+    @unittest.skipUnless(
+        sys.version_info >= (3, 13),
+        "loop.create_task with eager_start requires Python 3.13+",
+    )
+    def test_loop_create_task_eager_start(self):
+        async def coro():
+            return "eager"
+
+        async def main():
+            task = self.loop.create_task(coro(), eager_start=True)
+            self.assertTrue(task.done())
+            self.assertEqual(task.result(), "eager")
+
+        self.loop.run_until_complete(main())
+
+    @unittest.skipUnless(
+        sys.version_info >= (3, 14),
+        "asyncio.create_task with eager_start requires Python 3.14+",
+    )
+    def test_asyncio_create_task_eager_start(self):
+        async def coro():
+            return "eager"
+
+        async def main():
+            task = asyncio.create_task(coro(), eager_start=True)
+            self.assertTrue(task.done())
+            self.assertEqual(task.result(), "eager")
+
+        self.loop.run_until_complete(main())
+
     def test_shutdown_asyncgens_01(self):
         finalized = list()
 

--- a/uvloop/loop.pyi
+++ b/uvloop/loop.pyi
@@ -1,4 +1,5 @@
 import asyncio
+import contextvars
 import ssl
 import sys
 from socket import AddressFamily, SocketKind, _Address, _RetAddress, socket
@@ -46,12 +47,30 @@ class Loop:
     def is_running(self) -> bool: ...
     def is_closed(self) -> bool: ...
     def create_future(self) -> asyncio.Future[Any]: ...
-    def create_task(
-        self,
-        coro: Union[Awaitable[_T], Generator[Any, None, _T]],
-        *,
-        name: Optional[str] = ...,
-    ) -> asyncio.Task[_T]: ...
+    if sys.version_info >= (3, 13):
+        def create_task(
+            self,
+            coro: Union[Awaitable[_T], Generator[Any, None, _T]],
+            *,
+            name: Optional[str] = ...,
+            context: Optional[contextvars.Context] = ...,
+            eager_start: Optional[bool] = ...,
+        ) -> asyncio.Task[_T]: ...
+    elif sys.version_info >= (3, 11):
+        def create_task(
+            self,
+            coro: Union[Awaitable[_T], Generator[Any, None, _T]],
+            *,
+            name: Optional[str] = ...,
+            context: Optional[contextvars.Context] = ...,
+        ) -> asyncio.Task[_T]: ...
+    else:
+        def create_task(
+            self,
+            coro: Union[Awaitable[_T], Generator[Any, None, _T]],
+            *,
+            name: Optional[str] = ...,
+        ) -> asyncio.Task[_T]: ...
     def set_task_factory(
         self,
         factory: Optional[

--- a/uvloop/loop.pyx
+++ b/uvloop/loop.pyx
@@ -1404,7 +1404,7 @@ cdef class Loop:
         """Create a Future object attached to the loop."""
         return self._new_future()
 
-    def create_task(self, coro, *, name=None, context=None):
+    def create_task(self, coro, *, name=None, context=None, eager_start=None):
         """Schedule a coroutine object.
 
         Return a task object.
@@ -1417,7 +1417,12 @@ cdef class Loop:
         created when no context is provided.
         """
         self._check_closed()
-        if PY311:
+        if PY313:
+            if self._task_factory is None:
+                task = aio_Task(coro, loop=self, context=context, eager_start=eager_start)
+            else:
+                task = self._task_factory(self, coro, context=context, eager_start=eager_start)
+        elif PY311:
             if self._task_factory is None:
                 task = aio_Task(coro, loop=self, context=context)
             else:


### PR DESCRIPTION
This PR adds basic support for `eager_start` kwarg in `loop.create_task`.

Closes https://github.com/MagicStack/uvloop/issues/746, https://github.com/MagicStack/uvloop/issues/718

It also adjusts `loop.pyi` to mimic typeshed more closely as the type hints I was getting on my editor were not the ones I'd expect signature wise.

Currently it relies on these two PR's from being merged
* https://github.com/MagicStack/uvloop/pull/742
* https://github.com/MagicStack/uvloop/pull/743

I tested this manually on Linux and OSX by building uvloop from the branch and running it on eager_start workloads on python 3.13 and 3.14.

Disclosure: This PR is made by human-only contribution without AI generated code.