### PR TITLE
Fix debug-mode segfault when the asyncgen finalizer hook runs during frame teardown

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -720,6 +720,60 @@ class _TestBase:
         self.loop.run_until_complete(foo())
         self.loop.run_until_complete(asyncio.sleep(0.01))
 
+    def test_asyncgen_finalizer_hook_no_stack_capture(self):
+        # The finalizer hook can be invoked from a dealloc while the
+        # interpreter is mid-way through clearing a frame, where debug-mode
+        # source-traceback capture would walk a half-cleared frame and
+        # crash. Handles created while the suppression flag is set must not
+        # capture a traceback; normal handles must keep capturing.
+        if self.implementation != 'uvloop':
+            raise unittest.SkipTest('uvloop only')
+
+        from uvloop.loop import _extract_stack_disabled
+
+        self.loop.set_debug(True)
+        try:
+            handle = self.loop.call_soon(lambda: None)
+            self.assertIsNotNone(handle._source_traceback)
+            handle.cancel()
+
+            _extract_stack_disabled.flag = True
+            try:
+                handle = self.loop.call_soon(lambda: None)
+                self.assertIsNone(handle._source_traceback)
+                handle.cancel()
+            finally:
+                _extract_stack_disabled.flag = False
+        finally:
+            self.loop.set_debug(False)
+
+    def test_asyncgen_finalizer_hook_flag_reentrant(self):
+        # The hook must save/restore the suppression flag, not set/clear it:
+        # allocations inside the hook can trigger a GC that re-enters it on
+        # the same thread, and a clobbering reset would reopen the unsafe
+        # window for the outer invocation.
+        if self.implementation != 'uvloop':
+            raise unittest.SkipTest('uvloop only')
+
+        from uvloop.loop import _extract_stack_disabled
+
+        async def waiter():
+            yield 1
+
+        async def make_agen():
+            agen = waiter()
+            await agen.asend(None)
+            return agen
+
+        agen = self.loop.run_until_complete(make_agen())
+        _extract_stack_disabled.flag = True  # simulate an outer invocation
+        try:
+            self.loop._asyncgen_finalizer_hook(agen)
+            self.assertTrue(_extract_stack_disabled.flag)
+        finally:
+            _extract_stack_disabled.flag = False
+        self.loop.run_until_complete(asyncio.sleep(0.01))
+
     def test_inf_wait_for(self):
         async def foo():
             await asyncio.sleep(0.1)

--- a/uvloop/cbhandles.pyx
+++ b/uvloop/cbhandles.pyx
@@ -416,10 +416,23 @@ cdef new_MethodHandle3(Loop loop, str name, method3_t callback, object context,
     return handle
 
 
+class _ExtractStackDisabled(threading_local):
+    # Per-thread: True while handles are created from the asyncgen finalizer
+    # hook, which a dealloc can invoke while CPython is mid-way through
+    # clearing the current frame; sys._getframe() would then dereference the
+    # half-cleared frame and crash the interpreter.
+    flag = False
+
+
+_extract_stack_disabled = _ExtractStackDisabled()
+
+
 cdef extract_stack():
     """Replacement for traceback.extract_stack() that only does the
     necessary work for asyncio debug mode.
     """
+    if _extract_stack_disabled.flag:
+        return None
     try:
         f = sys_getframe()
     # sys._getframe() might raise ValueError if being called without a frame, e.g.
@@ -433,6 +446,10 @@ cdef extract_stack():
         stack = tb_StackSummary.extract(tb_walk_stack(f),
                                         limit=DEBUG_STACK_DEPTH,
                                         lookup_lines=False)
+    except (AttributeError, ValueError, TypeError):
+        # walk_stack can encounter non-frame objects, e.g. py3.14 surfaces
+        # _asyncio.TaskStepMethWrapper, which has no f_back (#715).
+        return None
     finally:
         f = None
 

--- a/uvloop/includes/stdlib.pxi
+++ b/uvloop/includes/stdlib.pxi
@@ -139,6 +139,7 @@ cdef int ssl_SSL_ERROR_WANT_WRITE = ssl.SSL_ERROR_WANT_WRITE
 cdef int ssl_SSL_ERROR_SYSCALL = ssl.SSL_ERROR_SYSCALL
 
 cdef threading_Thread = threading.Thread
+cdef threading_local = threading.local
 cdef threading_main_thread = threading.main_thread
 
 cdef int subprocess_PIPE = subprocess.PIPE

--- a/uvloop/loop.pyx
+++ b/uvloop/loop.pyx
@@ -3195,7 +3195,16 @@ cdef class Loop:
     def _asyncgen_finalizer_hook(self, agen):
         self._asyncgens.discard(agen)
         if not self.is_closed():
-            self.call_soon_threadsafe(self.create_task, agen.aclose())
+            # Frame walking is unsafe in this hook; see
+            # _ExtractStackDisabled in cbhandles.pyx. Save/restore (not
+            # set/clear): an allocation below can trigger a GC that
+            # re-enters this hook on the same thread.
+            prev = _extract_stack_disabled.flag
+            _extract_stack_disabled.flag = True
+            try:
+                self.call_soon_threadsafe(self.create_task, agen.aclose())
+            finally:
+                _extract_stack_disabled.flag = prev
 
     def _asyncgen_firstiter_hook(self, agen):
         if self._asyncgens_shutdown_called:


### PR DESCRIPTION
## Summary

In debug mode, `Loop._asyncgen_finalizer_hook` can segfault the interpreter. The hook is invoked by the GC from a dealloc — which can happen **while CPython is mid-way through clearing the current interpreter frame** — and the `call_soon_threadsafe` it performs creates a `Handle` whose debug source-traceback capture calls `sys._getframe()`, dereferencing the half-cleared frame.

We hit this in production on CPython 3.13.14 with uvloop 0.22.1: enabling `loop.set_debug(True)` on a Starlette/FastAPI service with streaming request bodies (`request.stream()` is an async generator; under disconnect/cancellation churn they are GC'd constantly) produced worker SIGSEGVs within seconds. Reproduces on 3.13.14 and 3.14.4, x86_64 and aarch64. It appears to be the same underlying weakness as #715 (there, on 3.14, the capture path surfaces a non-frame object to `traceback.walk_stack`).

## Symbolized backtrace (uvloop built `-O0 -g3`, CPython 3.13.14)

```
#3  ?? libpython3.13 (sys._getframe impl; SEGV reading frame->frame_obj)
#4  ?? libpython3.13
#5  __pyx_f_6uvloop_4loop_extract_stack ()                    at cbhandles.pyx (extract_stack)
#6  __pyx_f_6uvloop_4loop_6Handle__set_loop ()                at cbhandles.pyx (Handle._set_loop)
#7  __pyx_f_6uvloop_4loop_new_Handle ()
#8  __pyx_pf_6uvloop_4loop_4Loop_14call_soon_threadsafe ()
#11 __pyx_pf_6uvloop_4loop_4Loop_140_asyncgen_finalizer_hook ()
#14 PyObject_CallOneArg
#16 PyObject_CallFinalizerFromDealloc          <- asyncgen GC'd from a dealloc...
#19 _PyEval_FrameClearAndPop                   <- ...while this frame is being cleared
#20 _PyEval_EvalFrameDefault
```

A production core dump shows the same failure from the release wheel: SIGSEGV (SEGV_MAPERR) inside `sys._getframe` incref'ing `frame->frame_obj` containing a torn value (`0x3000000010`).

## Fix

- `_asyncgen_finalizer_hook` sets a per-thread flag (the hook can run on any thread) so `extract_stack()` skips frame introspection for the handle it creates. The source traceback of a GC point is arbitrary victim code anyway, so nothing meaningful is lost.
- `extract_stack()` additionally tolerates `AttributeError`/`ValueError`/`TypeError` from `StackSummary.extract`/`walk_stack`, returning `None` instead of propagating — this also addresses the 3.14 failure mode reported in #715 (`_asyncio.TaskStepMethWrapper` lacking `f_back`).

## Reproducer

Crashes in <15 s unpatched (verified end-to-end from a clean directory containing only these files: 271 `Fatal Python error` lines in a 60 s window, current PyPI starlette/fastapi/uvicorn); clean with this fix (10 min, ~259k streamed requests, verified on 3.13.14 aarch64 and x86_64).

<details>
<summary>app.py + load.py + docker command</summary>

```python
# app.py — needs: pip install uvicorn starlette fastapi httpx uvloop
from fastapi import FastAPI, Request
from starlette.middleware.base import BaseHTTPMiddleware

app = FastAPI()

class Passthrough(BaseHTTPMiddleware):
    async def dispatch(self, request, call_next):
        return await call_next(request)

app.add_middleware(Passthrough)
app.add_middleware(Passthrough)

@app.post("/upload")
async def upload(request: Request) -> dict:
    total = 0
    async for chunk in request.stream():
        total += len(chunk)
    return {"received": total}

# loop_factory.py
import uvloop
def new_event_loop():
    loop = uvloop.new_event_loop()
    loop.set_debug(True)          # <- the trigger
    return loop
```

```python
# load.py — 32 concurrent chunked uploads in a loop
import asyncio, httpx

async def body():
    for _ in range(200):
        yield b"x" * 2048

async def worker(client):
    while True:
        try:
            await client.post("http://localhost:8000/upload", content=body())
        except Exception:
            await asyncio.sleep(0.05)

async def main():
    async with httpx.AsyncClient(timeout=30) as c:
        await asyncio.gather(*[worker(c) for _ in range(32)])

asyncio.run(main())
```

```sh
docker run --rm -v $PWD:/r python:3.13.14-slim sh -c '
  pip install -q uvloop==0.22.1 uvicorn starlette fastapi httpx httptools
  cd /r
  PYTHONFAULTHANDLER=1 uvicorn app:app --workers 4 --port 8000 \
    --loop loop_factory:new_event_loop --http httptools &
  sleep 8
  python load.py &
  sleep 60
  # -> "Fatal Python error: Segmentation fault" within ~15s of load starting
'
```

</details>

## Performance

Stock = master merge base (e8efea4), patched = this branch (including the save/restore hook); both built from the same tree with identical flags (aarch64, CPython 3.13.14, best-of-3):

| path | stock | patched | delta |
|---|---|---|---|
| `call_soon` + cancel, non-debug | 0.125 µs | 0.129 µs | noise (≤4 ns, sign flips between sessions) |
| asyncgen create→finalize, non-debug | 1.491 µs | 1.631 µs | +140 ns (three thread-local ops in the hook) |
| `call_soon` + cancel, debug | 3.337 µs | 3.376 µs | ~1% (within noise) |
| asyncgen create→finalize, debug | 11.836 µs | 7.368 µs | −38% (skips the now-pointless capture) |

Non-debug hot paths are untouched by construction (`extract_stack` is only reachable under `loop._debug`); the only non-debug cost is the thread-local save/set/restore per GC'd async generator, on a path whose real cost is dominated by `uv_async_send` plus the subsequently scheduled `create_task`/`aclose()`.

## Behavior change

In debug mode, the handle scheduling `agen.aclose()` from the finalizer hook no longer carries `_source_traceback`. Previously it captured the stack of whichever code happened to be running when GC fired — misleading rather than useful. Task-level debug tracebacks (`create_task` runs later in normal loop context) and `firstiter` capture are unaffected.

Validated with the reproducer plus targeted checks (normal handles still get `_source_traceback` in debug mode; asyncgen finalizer path executes cleanly); relying on CI for the full test matrix.
