### PR TITLE
Fix epoll test cleanup on Python 3.15

### DIFF
--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import pickle
 import select
 import socket
@@ -272,7 +273,9 @@ class TestUVSockets(_TestSockets, tb.UVTestCase):
         # See https://github.com/MagicStack/uvloop/issues/61 for details
 
         sock = socket.socket()
-        epoll = select.epoll.fromfd(self.loop._get_backend_id())
+        # Keep a separate descriptor for the backend epoll instance.  The loop
+        # owns its descriptor and closes it when the loop is closed.
+        epoll = select.epoll.fromfd(os.dup(self.loop._get_backend_id()))
 
         try:
             cb = lambda: None
@@ -288,8 +291,8 @@ class TestUVSockets(_TestSockets, tb.UVTestCase):
 
         finally:
             sock.close()
-            self.loop.close()
             epoll.close()
+            self.loop.close()
 
     def test_add_reader_or_writer_transport_fd(self):
         def assert_raises():


### PR DESCRIPTION
## Summary

Keep the test-owned `epoll` wrapper on a duplicate of uvloop's backend descriptor. The loop retains ownership of its descriptor and closes it itself.

This preserves the existing assertion that `remove_reader()` removes the socket from the same epoll instance, while avoiding a second close after `loop.close()` on Python 3.15.

## Validation

On Ubuntu 24.04 with locally built uvloop `master`:

- Python 3.14.7 free-threaded: `TestUVSockets.test_socket_sync_remove` passes
- Python 3.15.0rc1: test passes
- Python 3.15.0rc1 free-threaded: test passes

## Why draft

Current source builds and basic loop smoke tests on 3.15/3.15t, but this is only a test-cleanup prerequisite, not a claim of complete 3.15 support. The full 3.15t optional test dependencies are currently blocked upstream: `pyOpenSSL~=25.3.0` resolves to cryptography 46.0.7, whose PyO3 build rejects Python 3.15 free-threaded. I will not add 3.15/3.15t CI or release-wheel targets until that complete suite can run green.