### PR TITLE
Reject a None loop in Server's constructor instead of crashing later

### DIFF
--- a/tests/test_regr1.py
+++ b/tests/test_regr1.py
@@ -2,6 +2,8 @@ import asyncio
 import queue
 import multiprocessing
 import signal
+import subprocess
+import sys
 import threading
 import unittest
 
@@ -117,3 +119,32 @@ class TestIssue39Regr(tb.UVTestCase):
         finally:
             self.running = False
             signal.signal(signal.SIGALRM, signal.SIG_IGN)
+
+
+class TestIssue760Regr(unittest.TestCase):
+    """See https://github.com/MagicStack/uvloop/issues/760 for details.
+
+    Directly constructing uvloop.loop.Server with a loop of None isn't a
+    supported usage pattern, but it segfaulted instead of raising a
+    Python exception, since the None was only checked much later, deep
+    inside close(). Run the reproducer in a subprocess since a regression
+    here crashes the whole interpreter rather than raising.
+    """
+
+    def test_server_with_none_loop_raises_instead_of_crashing(self):
+        code = (
+            "from uvloop.loop import Server\n"
+            "server = Server(None)\n"
+            "server.close()\n"
+        )
+        proc = subprocess.run(
+            [sys.executable, '-c', code],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE)
+
+        self.assertNotEqual(
+            proc.returncode, -11,
+            f'process was killed by SIGSEGV; stderr:\n'
+            f'{proc.stderr.decode()}')
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn(b'TypeError', proc.stderr)

--- a/uvloop/server.pyx
+++ b/uvloop/server.pyx
@@ -2,7 +2,7 @@ import asyncio
 
 
 cdef class Server:
-    def __cinit__(self, Loop loop):
+    def __cinit__(self, Loop loop not None):
         self._loop = loop
         self._servers = []
         self._waiters = []


### PR DESCRIPTION
Fixes #760

`uvloop.loop.Server` is only ever constructed internally with `Server(self)`, but the constructor accepted anything since `Loop loop` doesn't say `not None`. As reported, `Server(None)` builds fine, and calling `close()` on it segfaults instead of raising, because `self._loop` is a typed cdef attribute and Cython's attribute access on it skips the usual None check that a plain Python object reference would get. The crash happens deep inside `_unref()`, well past where the bad input was actually supplied.

Traced the actual path with the ASan trace from the issue: `close()` calls `_unref()` in its `finally` block, which does `self._loop._servers.discard(self)`. With `self._loop` set to `None`, that ends up dereferencing garbage instead of raising `AttributeError` the way ordinary Python code would, which lines up with the `PyType_IsSubtype` / `__Pyx_PySet_Discard` frames in the report.

Marking the parameter `Loop loop not None` makes the constructor reject bad input immediately with a clean `TypeError`, which is what the reporter expected in the first place. Checked both call sites in `loop.pyx` (`create_server` and the Unix socket path) and they already pass `self`, a real `Loop`, so this doesn't affect any real usage.

Reproduced the crash locally first (built from source with the constructor unchanged, confirmed `Server(None); server.close()` segfaults with exit code 139) before writing the fix, then confirmed the same reproducer raises a clean `TypeError` afterward. Added `test_server_with_none_loop_raises_instead_of_crashing` in `tests/test_regr1.py`, run in a subprocess since without the fix it takes down the whole interpreter rather than failing normally. Reverting just the constructor change makes that test fail with the SIGSEGV assertion, confirming it actually exercises the bug.

Ran the full `tests/test_tcp.py` suite (112 tests) afterward with no regressions, and `flake8` on the touched test file is clean.